### PR TITLE
fixed fuerte check for SetChuckingDirection

### DIFF
--- a/src/prpy/base/barretthand.py
+++ b/src/prpy/base/barretthand.py
@@ -49,10 +49,7 @@ class BarrettHand(EndEffector):
         EndEffector.__init__(self, manipulator)
         self.simulated = sim
 
-        import rospkg, distutils.version
-        ros_version = rospkg.RosStack().get_stack_version('ros')
-        if distutils.version.LooseVersion(ros_version) >= distutils.version.LooseVersion('1.9'):
-            # Just in case the closing direction is missing.
+        if len(manipulator.GetGripperIndices()) == 4:
             manipulator.SetChuckingDirection([ 0., 1., 1., 1. ])
 
         # Hand controller


### PR DESCRIPTION
SetChuckingDirection is failing on my machine. Not sure whether that's because of fuerte (I don't see how that could be), the way fuerte is loading herb, or something else.

Here's the error I get:

openravepy._openravepy_.openravepy_ext.openrave_exception: openrave (Assert): [virtual void OpenRAVE::RobotBase::Manipulator::SetChuckingDirection(const std::vector<double>&):64](int)chuckingdirection.size() == GetGripperDOF(), (eval 4 == 3)

Any thoughts on whether this is how fuerte loads herb or something else? If its something else I'll change this PR to just removing the check.
