### PR TITLE
Removed robot-specific imports from PrPy

### DIFF
--- a/src/prpy/base/__init__.py
+++ b/src/prpy/base/__init__.py
@@ -32,11 +32,3 @@ from robot import Robot
 from manipulator import Manipulator
 from endeffector import EndEffector
 from mobilebase import MobileBase
-
-from wam import WAM
-from wamrobot import WAMRobot
-from barretthand import BarrettHand
-
-from mico import Mico
-from micorobot import MicoRobot
-from micohand import MicoHand


### PR DESCRIPTION
Fix for #6. This will require companion changes in HerbPy and AdaPy.

In the long term, we should probably migrate `wam`, `wamrobot`, `barretthand`, `mico`, `micorobot`, and `micohand` into special-purpose packages.