### PR TITLE
SimplifyTrajectory function.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -156,7 +156,8 @@ class Robot(openravepy.Robot):
         from prpy.util import CopyTrajectory, SimplifyTrajectory
 
         # Simplify the trajectory before performing retiming.
-        traj = SimplifyTrajectory(traj, self)
+        if traj.GetDuration() == 0.0:
+            traj = SimplifyTrajectory(traj, self)
 
         # Attempt smoothing with the Parabolic Retimer first.
         smooth_traj = CopyTrajectory(traj)

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -262,7 +262,7 @@ def SimplifyTrajectory(traj, robot):
         max_err_vals = numpy.max(errors, axis=0)
 
         # Add any extrema that deviated more than joint resolution.
-        max_err_idx = (max_err_vals > resolutions)
+        max_err_idx = max_err_idx[max_err_vals > resolutions]
         mask[max_err_idx] = True
 
         # If none deviated more than joint resolution, the set is complete.

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -229,6 +229,9 @@ def SimplifyTrajectory(traj, robot):
     """
     from scipy import interpolate
 
+    if traj.GetDuration() != 0.0:
+        raise ValueError("Cannot handle timed trajectories yet!")
+
     cspec = traj.GetConfigurationSpecification()
     dofs = robot.GetActiveDOFIndices()
     idxs = range(traj.GetNumWaypoints())
@@ -237,8 +240,7 @@ def SimplifyTrajectory(traj, robot):
     times = numpy.array(
         idxs if not traj.GetDuration() else
         numpy.cumsum([cspec.ExtractDeltaTime(traj.GetWaypoint(i),
-                                             robot, dofs)
-                      for i in idxs]))
+                                             robot, dofs) for i in idxs]))
     values = numpy.array(
         [cspec.ExtractJointValues(traj.GetWaypoint(i), robot, dofs)
          for i in idxs])


### PR DESCRIPTION
Implements a linear segments path simplification function in prpy.util that interpolates between
set of waypoints, starting at the end and iteratively adding the highest error intermediate
waypoints until a set of line segments is created that approximates the original waypoints up to
the joint_dof_resolution of an OpenRAVE robot.