### PR TITLE
Feature: Planning futures

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -293,6 +293,13 @@ class Robot(openravepy.Robot):
 
         # Optionally execute the trajectory.
         if 'execute' not in kw_args or kw_args['execute']:
-            return self.ExecuteTrajectory(traj, **kw_args)
+            if 'defer' in kw_args and kw_args['defer'] is True:
+                import trollius
+                with kw_args['executor'] or \
+                        trollius.executor.get_default_executor() as executor:
+                    return executor.submit(self.ExecuteTrajectory,
+                                           traj.result(), kw_args)
+            else:
+                return self.ExecuteTrajectory(traj, **kw_args)
         else:
             return traj

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -284,9 +284,6 @@ class Robot(openravepy.Robot):
         return False
 
     def _PlanWrapper(self, planning_method, args, kw_args):
-        print "H"
-        import IPython
-        IPython.embed()
 
         # Call the planner.
         traj = planning_method(self, *args, **kw_args)

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -307,7 +307,7 @@ class Robot(openravepy.Robot):
         def defer_trajectory(traj_future, kw_args):
             postprocess_trajectory(traj_future.result(), kw_args)
 
-        # Return the trajectory result or a future to the result.
+        # Return either the trajectory result or a future to the result.
         if 'defer' in kw_args and kw_args['defer'] is True:
             from trollius.executor import get_default_executor
             with kw_args.get('executor') or get_default_executor() as executor:

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -312,6 +312,7 @@ class Robot(openravepy.Robot):
 
             # Optionally execute the trajectory.
             if 'execute' not in kw_args or kw_args['execute']:
+                kw_args['defer'] = False
                 return self.ExecuteTrajectory(traj, **kw_args)
             else:
                 return traj

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -305,7 +305,7 @@ class Robot(openravepy.Robot):
 
         # Perform postprocessing on a future trajectory.
         def defer_trajectory(traj_future, kw_args):
-            postprocess_trajectory(traj_future.result(), kw_args)
+            return postprocess_trajectory(traj_future.result(), kw_args)
 
         # Return either the trajectory result or a future to the result.
         if 'defer' in kw_args and kw_args['defer'] is True:

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -284,6 +284,10 @@ class Robot(openravepy.Robot):
         return False
 
     def _PlanWrapper(self, planning_method, args, kw_args):
+        print "H"
+        import IPython
+        IPython.embed()
+
         # Call the planner.
         traj = planning_method(self, *args, **kw_args)
 

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -310,7 +310,7 @@ class Robot(openravepy.Robot):
         # Return either the trajectory result or a future to the result.
         if 'defer' in kw_args and kw_args['defer'] is True:
             from trollius.executor import get_default_executor
-            with kw_args.get('executor') or get_default_executor() as executor:
-                return executor.submit(defer_trajectory, result, kw_args)
+            executor = kw_args.get('executor') or get_default_executor()
+            return executor.submit(defer_trajectory, result, kw_args)
         else:
             return postprocess_trajectory(result, kw_args)

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -151,11 +151,10 @@ class MetaPlanner(Planner):
             executor = kw_args.get('executor')
 
             if defer is True:
-                import trollius
-                with executor or trollius.executor.get_default_executor() \
-                        as executor:
+                from trollius.executor import get_default_executor
+                with executor or get_default_executor() as executor:
                     return executor.submit(
-                        self.plan, (method_name, args, kw_args)
+                        self.plan, method_name, args, kw_args
                     )
             else:
                 return self.plan(method_name, args, kw_args)

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -242,7 +242,7 @@ class Ranked(MetaPlanner):
         executor = kw_args.get('executor')
         all_planners = self._planners
         planners = []
-        results = [None]*len(self._planners)
+        results = [None] * len(self._planners)
 
         # Find only planners that support the required planning method.
         for index, planner in enumerate(all_planners):

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -69,9 +69,8 @@ class PlanningMethod(object):
                 return traj
 
             if defer is True:
-                import trollius
-                with executor or trollius.executor.get_default_executor() \
-                        as executor:
+                from trollius.executor import get_default_executor
+                with executor or get_default_executor() as executor:
                     return executor.submit(call_planner)
             else:
                 return call_planner()
@@ -270,9 +269,8 @@ class Ranked(MetaPlanner):
 
         # Call every planners in parallel using a concurrent executor and
         # return the first non-error result in the ordering when available.
-        import trollius
-        with executor or trollius.executor.get_default_executor() \
-                as executor:
+        from trollius.executor import get_default_executor
+        with executor or get_default_executor() as executor:
             for _ in executor.map(call_planner, planners):
                 for result in results:
                     if result is None:

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -54,8 +54,8 @@ class PlanningMethod(object):
         env = robot.GetEnv()
         defer = kw_args.get('defer')
 
-        with Clone(env, clone_env=instance.env, lock=True, unlock=False) \
-                as cloned_env:
+        with Clone(env, clone_env=instance.env,
+                   lock=True, unlock=False) as cloned_env:
 
             def call_planner():
                 planning_traj = self.func(instance, Cloned(robot),

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -30,6 +30,7 @@
 
 import abc, logging, functools, openravepy
 from ..clone import Clone, Cloned
+from ..util import CopyTrajectory
 
 logger = logging.getLogger('planning')
 
@@ -45,6 +46,7 @@ class MetaPlanningError(PlanningError):
         self.errors = errors
 
     # TODO: Print the inner exceptions.
+
 
 class PlanningMethod(object):
     def __init__(self, func):
@@ -62,11 +64,7 @@ class PlanningMethod(object):
                 try:
                     planner_traj = self.func(instance, cloned_robot,
                                              *args, **kw_args)
-                    traj = openravepy.RaveCreateTrajectory(
-                        env, planner_traj.GetXMLId()
-                    )
-                    traj.Clone(planner_traj, 0)
-                    return traj
+                    return CopyTrajectory(planner_traj, env=env)
                 finally:
                     cloned_env.Unlock()
 
@@ -84,6 +82,7 @@ class PlanningMethod(object):
         functools.update_wrapper(wrapper, self.func)
         wrapper.is_planning_method = True
         return wrapper
+
 
 class Planner(object):
     def has_planning_method(self, method_name):

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -66,6 +66,7 @@ class PlanningMethod(object):
                 )
                 traj.Clone(planning_traj, 0)
                 cloned_env.Unlock()
+                return traj
 
             if defer is True:
                 import trollius

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -56,16 +56,19 @@ class PlanningMethod(object):
 
         with Clone(env, clone_env=instance.env,
                    lock=True, unlock=False) as cloned_env:
+            cloned_robot = Cloned(robot)
 
             def call_planner():
-                planning_traj = self.func(instance, Cloned(robot),
-                                          *args, **kw_args)
-                traj = openravepy.RaveCreateTrajectory(
-                    env, planning_traj.GetXMLId()
-                )
-                traj.Clone(planning_traj, 0)
-                cloned_env.Unlock()
-                return traj
+                try:
+                    planner_traj = self.func(instance, cloned_robot,
+                                             *args, **kw_args)
+                    traj = openravepy.RaveCreateTrajectory(
+                        env, planner_traj.GetXMLId()
+                    )
+                    traj.Clone(planner_traj, 0)
+                    return traj
+                finally:
+                    cloned_env.Unlock()
 
             if defer is True:
                 from trollius.executor import get_default_executor

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -200,13 +200,16 @@ def AdaptTrajectory(traj, new_start, new_goal, robot):
     new_traj = MatrixToTraj(new_traj_matrix,cs,dof,robot)
     return new_traj
 
-def CopyTrajectory(traj):
+
+def CopyTrajectory(traj, env=None):
     """
     Create a new copy of a trajectory using its Clone() operator.
+
     @param traj input trajectory
+    @param env optional environment used to initialize a trajectory
     @return copy of the trajectory
     """
-    copy_traj = openravepy.RaveCreateTrajectory(traj.GetEnv(),
+    copy_traj = openravepy.RaveCreateTrajectory(env or traj.GetEnv(),
                                                 traj.GetXMLId())
     copy_traj.Clone(traj, 0)
     return copy_traj


### PR DESCRIPTION
This PR adds the ability to pass a `defer=True` flag and an optional `executor` to planning methods.  The `defer` flag causes planning operations to be submitted to a thread executor and immediately return a `Future` which can be queried for the result of the planning call.  This can also be used with `execute=True` to execute trajectories concurrently with other operations.

Use of the `defer` flag requires the installation of python-trollius (https://bitbucket.org/enovance/trollius), a backport of the Python 3 asyncio library.  This dependency is not required if the `defer` flag is not used.