### PR TITLE
Fixed missing and child-referencing constructors in CloneBindings.

### DIFF
--- a/src/prpy/base/endeffector.py
+++ b/src/prpy/base/endeffector.py
@@ -30,9 +30,15 @@
 
 import openravepy
 
+
 class EndEffector(openravepy.Robot.Link):
     def __init__(self, manipulator):
         self.manipulator = manipulator
+
+    def CloneBindings(self, parent):
+        from ..clone import Cloned
+        EndEffector.__init__(self, Cloned(parent.manipulator,
+                                          into=self.GetParent().GetEnv()))
 
     def GetIndices(self):
         """Gets the DOF indicies associated with this end-effector.

--- a/src/prpy/base/manipulator.py
+++ b/src/prpy/base/manipulator.py
@@ -31,13 +31,14 @@
 import copy, functools, numpy, openravepy
 from .. import bind, clone, planning
 
+
 class Manipulator(openravepy.Robot.Manipulator):
     def __init__(self):
         pass
 
     def __dir__(self):
         # We have to manually perform a lookup in InstanceDeduplicator because
-        # __methods__ bypass __getattribute__. 
+        # __methods__ bypass __getattribute__.
         self = bind.InstanceDeduplicator.get_canonical(self)
 
         # Add planning methods to the tab-completion list.
@@ -47,7 +48,7 @@ class Manipulator(openravepy.Robot.Manipulator):
 
     def __getattr__(self, name):
         # We have to manually perform a lookup in InstanceDeduplicator because
-        # __methods__ bypass __getattribute__. 
+        # __methods__ bypass __getattribute__.
         self = bind.InstanceDeduplicator.get_canonical(self)
         delegate_method = getattr(self.GetRobot().planner, name)
 
@@ -56,14 +57,14 @@ class Manipulator(openravepy.Robot.Manipulator):
         if self.GetRobot().planner.has_planning_method(name):
             @functools.wraps(delegate_method)
             def wrapper_method(*args, **kw_args):
-                return self._PlanWrapper(delegate_method, args, kw_args) 
+                return self._PlanWrapper(delegate_method, args, kw_args)
 
             return wrapper_method
 
         raise AttributeError('{0:s} is missing method "{1:s}".'.format(repr(self), name))
 
     def CloneBindings(self, parent):
-        self.__init__(self)
+        Manipulator.__init__(self)
 
     def GetIndices(self):
         """Gets the DOF indicies associated with this manipulaor.

--- a/src/prpy/base/mobilebase.py
+++ b/src/prpy/base/mobilebase.py
@@ -69,9 +69,8 @@ class MobileBase(object):
 
         raise AttributeError('{0:s} is missing method "{1:s}".'.format(repr(self), name))
 
-
     def CloneBindings(self, parent):
-        self.__init__(True, None)
+        MobileBase.__init__(self, True, None)
 
     def Forward(self, meters, execute=True, direction=None, **kw_args):
         """

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -38,14 +38,14 @@ logger = logging.getLogger('robot')
 class Robot(openravepy.Robot):
     def __init__(self, robot_name=None):
         self.planner = None
+        self.robot_name = robot_name
 
         try:
             self.tsrlibrary = TSRLibrary(self, robot_name=robot_name)
         except ValueError as e:
             self.tsrlibrary = None
             logger.warning('Failed creating TSRLibrary for robot "%s": %s',
-                self.GetName(), e.message
-            )
+                           self.GetName(), e.message)
 
         self.controllers = list()
         self.manipulators = list()
@@ -59,7 +59,7 @@ class Robot(openravepy.Robot):
 
     def __dir__(self):
         # We have to manually perform a lookup in InstanceDeduplicator because
-        # __methods__ bypass __getattribute__. 
+        # __methods__ bypass __getattribute__.
         self = bind.InstanceDeduplicator.get_canonical(self)
 
         # Add planning methods to the tab-completion list.
@@ -69,7 +69,7 @@ class Robot(openravepy.Robot):
 
     def __getattr__(self, name):
         # We have to manually perform a lookup in InstanceDeduplicator because
-        # __methods__ bypass __getattribute__. 
+        # __methods__ bypass __getattribute__.
         self = bind.InstanceDeduplicator.get_canonical(self)
         delegate_method = getattr(self.planner, name)
 
@@ -77,22 +77,17 @@ class Robot(openravepy.Robot):
         if self.planner.has_planning_method(name):
             @functools.wraps(delegate_method)
             def wrapper_method(*args, **kw_args):
-                return self._PlanWrapper(delegate_method, args, kw_args) 
+                return self._PlanWrapper(delegate_method, args, kw_args)
 
             return wrapper_method
 
         raise AttributeError('{0:s} is missing method "{1:s}".'.format(repr(self), name))
 
     def CloneBindings(self, parent):
+        Robot.__init__(self, parent.robot_name)
         self.planner = parent.planner
-        self.controllers = list()
         self.manipulators = [ Cloned(manipulator) for manipulator in parent.manipulators ]
         self.configurations = parent.configurations
-        self.multicontroller = openravepy.RaveCreateMultiController(self.GetEnv(), '')
-        self.SetController(self.multicontroller)
-
-        self.base_manipulation = openravepy.interfaces.BaseManipulation(self)
-        self.task_manipulation = openravepy.interfaces.TaskManipulation(self)
 
     def AttachController(self, name, args, dof_indices, affine_dofs, simulated):
         """
@@ -117,7 +112,7 @@ class Robot(openravepy.Robot):
             raise openravepy.openrave_exception(message)
 
         self.multicontroller.AttachController(delegate_controller, dof_indices, affine_dofs)
-                
+
         return delegate_controller
 
     def GetTrajectoryManipulators(self, traj):


### PR DESCRIPTION
This PR standardizes the calling of constructors within the CloneBindings functions of prpy.base classes.

1) Each class constructor is called directly (not the instance constructor).
2) EndEffector has a CloneBindings function now.