### PR TITLE
Added bugfix for cloning grabbed objects.

### DIFF
--- a/src/prpy/clone.py
+++ b/src/prpy/clone.py
@@ -87,6 +87,24 @@ class Clone(object):
             # PrPy-annotated classes.
             setattr(self.clone_env, 'clone_parent', self.clone_parent)
 
+            # Due to a bug in the OpenRAVE clone API, we need to regrab
+            # objects in cloned environments because they might have
+            # incorrectly computed 'ignore' flags.
+            # TODO(pkv): Remove this block once OpenRAVE cloning is fixed.
+            for robot in self.clone_parent.GetRobots():
+                # Since the new ignore lists are computed from the current
+                # pose,  calling RegrabAll() from a pose that is in
+                # SelfCollision may incorrectly ignore collisions.
+                if robot.CheckSelfCollision():
+                    raise CloneException(
+                        'Unable to compute self-collisions correctly. '
+                        'Robot {:s} was cloned while in collision.'
+                        .format(robot.GetName())
+                    )
+                cloned_robot = self.clone_env.Cloned(robot)
+                with self.clone_env:
+                    cloned_robot.RegrabAll()
+
     def __enter__(self):
         if self.lock:
             self.clone_env.Lock()


### PR DESCRIPTION
Due to a bug in OpenRAVE, cloned grabbed objects may have incorrect adjacency properties, causing them to not be evaluated correctly for self collisions (with the robot).  This bugfix forces cloned environments to regrab all objects, which resets these incorrect links.
