### PR TITLE
Bugfix: IK Ranking and SimplifyTrajectory

### DIFF
--- a/src/prpy/ik_ranking.py
+++ b/src/prpy/ik_ranking.py
@@ -53,13 +53,26 @@ def JointLimitAvoidance(robot, ik_solutions):
 
 
 class NominalConfiguration(object):
-    def __init__(self, q_nominal):
+    def __init__(self, q_nominal, max_deviation=2*numpy.pi):
         """
         Score IK solutions by their distance from a nominal configuration.
         @param q_nominal nominal configuration
+        @param max_deviation specify a maximum allowable per-joint deviation
+                             from the nominal configuration, default is 2*PI
         """
         self.q_nominal = q_nominal
+        self.max_deviation = max_deviation
 
     def __call__(self, robot, ik_solutions):
         assert ik_solutions.shape[1] == self.q_nominal.shape[0]
-        return numpy.linalg.norm(ik_solutions - self.q_nominal, axis=1)
+        L_2 = numpy.linalg.norm(ik_solutions - self.q_nominal,
+                                axis=1, ord=2)
+
+        # Ignore IK solutions that are more than the specified distance away.
+        # (This means a closer solution must exist!)
+        if self.max_deviation is not None:
+            L_inf = numpy.linalg.norm(ik_solutions - self.q_nominal,
+                                      axis=1, ord=numpy.inf)
+            L_2[L_inf > self.max_deviation] = numpy.inf
+
+        return L_2

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -235,6 +235,9 @@ def SimplifyTrajectory(traj, robot):
     if traj.GetDuration() != 0.0:
         raise ValueError("Cannot handle timed trajectories yet!")
 
+    if traj.GetNumWaypoints() < 2:
+        return traj
+
     cspec = traj.GetConfigurationSpecification()
     dofs = robot.GetActiveDOFIndices()
     idxs = range(traj.GetNumWaypoints())


### PR DESCRIPTION
This PR adds handling of two special cases to planning utility functions `prpy.ik_ranking.NominalConfiguration` and `prpy.util.SimplifyTrajectory`.

* `SimplifyTrajectory` has been modified to gracefully return if passed a trajectory with only one waypoint.
* `NominalConfiguration` optionally takes a maximum allowable DOF range, which allows robots with fully redundant configurations (i.e. multiple rotation joints) to ignore IK configurations for which a closer solution must exist.