### PR TITLE
Added workspace planner to prpy.planning init.py

### DIFF
--- a/src/prpy/planning/__init__.py
+++ b/src/prpy/planning/__init__.py
@@ -38,3 +38,4 @@ from named import NamedPlanner
 from ik import IKPlanner
 from sbpl import SBPLPlanner
 from openrave import BiRRTPlanner
+from workspace import GreedyIKPlanner


### PR DESCRIPTION
This just adds the new workspace planner to `__init__.py` so it can be imported from `prpy.planning`.