### PR TITLE
Fixed a number of bugs related to workspace planner.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -176,7 +176,7 @@ class Robot(openravepy.Robot):
                       PlannerStatus.InterruptedWithSolution]:
             return retimed_traj
         raise PrPyException("Path retimer failed with status '{:s}'"
-                            .format(status))
+                            .format(str(status)))
 
     def ExecuteTrajectory(self, traj, retime=True, timeout=None,
                           defer=False, executor=None, **kw_args):

--- a/src/prpy/clone.py
+++ b/src/prpy/clone.py
@@ -61,7 +61,6 @@ class Clone(object):
         @param unlock unlock the environment when exiting the with-block
         @param options bitmask of CloningOptions
         """
-
         self.clone_parent = parent_env
         self.options = options
 
@@ -80,8 +79,9 @@ class Clone(object):
 
         # Actually clone.
         with self.clone_env:
-            with self.clone_parent:
-                self.clone_env.Clone(self.clone_parent, self.options)
+            if self.clone_env != self.clone_parent:
+                with self.clone_parent:
+                    self.clone_env.Clone(self.clone_parent, self.options)
 
             # Required for InstanceDeduplicator to call CloneBindings for
             # PrPy-annotated classes.
@@ -102,8 +102,7 @@ class Clone(object):
                         .format(robot.GetName())
                     )
                 cloned_robot = self.clone_env.Cloned(robot)
-                with self.clone_env:
-                    cloned_robot.RegrabAll()
+                cloned_robot.RegrabAll()
 
     def __enter__(self):
         if self.lock:

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -28,17 +28,23 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import abc, logging, functools, openravepy
-from ..clone import Clone, Cloned
+import abc
+import functools
+import logging
+import openravepy
+from ..clone import Clone
 from ..util import CopyTrajectory
 
 logger = logging.getLogger('planning')
 
+
 class PlanningError(Exception):
     pass
 
+
 class UnsupportedPlanningError(PlanningError):
     pass
+
 
 class MetaPlanningError(PlanningError):
     def __init__(self, message, errors):
@@ -201,7 +207,8 @@ class Sequence(MetaPlanner):
         return 'Sequence({0:s})'.format(', '.join(map(str, self._planners)))
 
     def get_planners(self, method_name):
-        return [ planner for planner in self._planners if hasattr(planner, method_name) ]
+        return [planner for planner in self._planners
+                if hasattr(planner, method_name)]
 
     def plan(self, method, args, kw_args):
         errors = dict()
@@ -233,7 +240,8 @@ class Ranked(MetaPlanner):
         return 'Ranked({0:s})'.format(', '.join(map(str, self._planners)))
 
     def get_planners(self, method_name):
-        return [ planner for planner in self._planners if hasattr(planner, method_name) ]
+        return [planner for planner in self._planners
+                if hasattr(planner, method_name)]
 
     def plan(self, method, args, kw_args):
         all_planners = self._planners


### PR DESCRIPTION
This PR addresses several major bugs unmasked by the workspace planner.
1. Fixed a bug in cloning an environment into itself
   (needed for recursive `@PlanningMethod`s)
2. Fixed a bug in incorrect formatting of RetimeTrajectory error messages.
3. Fixed numerous small issues in the workspace planner:
  * Returning a 1-waypoint trajectory when started in-contact with an object.
  * Fixed max_distance calculation error from missing `numpy.copy()`
  * Simplified some of the workspace planning logic.