### PR TITLE
Hide IK log spam when cloning environments

### DIFF
--- a/src/prpy/logger.py
+++ b/src/prpy/logger.py
@@ -54,7 +54,6 @@ def initialize_logging():
     # Remove all of the existing handlers.
     base_logger = logging.getLogger()
     for handler in base_logger.handlers:
-        print 'REMOVING', handler
         base_logger.removeHandler(handler)
 
     # Add the custom handler.
@@ -72,7 +71,11 @@ def initialize_logging():
         logging.warning('Install termcolor to colorize log messages.')
 
     # Disable spammy and ROS loggers.
-    spammy_logger_names = [ 'rospy.topics', 'openravepy.databases.inversekinematics' ]
+    spammy_logger_names = [
+        'rospy.topics',
+        'openravepy.inversekinematics',
+        'openravepy.databases.inversekinematics',
+    ]
     for spammy_logger_name in spammy_logger_names:
         spammy_logger = logging.getLogger(spammy_logger_name)
         spammy_logger.setLevel(logging.WARNING)


### PR DESCRIPTION
It appears that all of the `ikfast` spam migrated from the `openravepy.databases.inversekinematics` namespace to the `openravepy.inversekinematics` namespace. This pull request hides this spam by increasing the log level to `WARNING`.