### PR TITLE
Tag trajectories with information necessary to control smoothing

### DIFF
--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -33,7 +33,7 @@ import functools
 import logging
 import openravepy
 from ..clone import Clone
-from ..util import CopyTrajectory, SetTrajectoryTags
+from ..util import CopyTrajectory, GetTrajectoryTags, SetTrajectoryTags
 
 logger = logging.getLogger('planning')
 
@@ -70,14 +70,16 @@ class PlanningMethod(object):
                 try:
                     planner_traj = self.func(instance, cloned_robot,
                                              *args, **kw_args)
-                    copied_traj =  CopyTrajectory(planner_traj, env=env)
 
                     # Tag the trajectory with the planner and planning method
-                    # used to generate it.
-                    SetTrajectoryTags(copied_traj, {
-                        'planner': instance.__class__.__name__,
-                        'planning_method': self.func.__name__,
-                    })
+                    # used to generate it. We don't overwrite these tags if
+                    # they already exist.
+                    tags = GetTrajectoryTags(planner_traj)
+                    tags.setdefault('planner', instance.__class__.__name__)
+                    tags.setdefault('planning_method', self.func.__name__)
+                    SetTrajectoryTags(planner_traj, tags, append=False)
+
+                    return CopyTrajectory(planner_traj, env=env)
 
                     return copied_traj
                 finally:

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -33,7 +33,7 @@ import functools
 import logging
 import openravepy
 from ..clone import Clone
-from ..util import CopyTrajectory
+from ..util import CopyTrajectory, SetTrajectoryTags
 
 logger = logging.getLogger('planning')
 
@@ -70,7 +70,16 @@ class PlanningMethod(object):
                 try:
                     planner_traj = self.func(instance, cloned_robot,
                                              *args, **kw_args)
-                    return CopyTrajectory(planner_traj, env=env)
+                    copied_traj =  CopyTrajectory(planner_traj, env=env)
+
+                    # Tag the trajectory with the planner and planning method
+                    # used to generate it.
+                    SetTrajectoryTags(copied_traj, {
+                        'planner': instance.__class__.__name__,
+                        'planning_method': self.func.__name__,
+                    })
+
+                    return copied_traj
                 finally:
                     cloned_env.Unlock()
 

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import copy, logging, numpy, openravepy, os, tempfile
+from ..util import SetTrajectoryTags
 from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
 import prpy.kin, prpy.tsr
 
@@ -252,6 +253,10 @@ class CBiRRTPlanner(BasePlanner):
             traj_xml = traj_file.read()
             traj = openravepy.RaveCreateTrajectory(self.env, 'GenericTrajectory')
             traj.deserialize(traj_xml)
+
+        # Tag the trajectory as constrained if a constraint TSR is present.
+        if any(tsr_chain.constrain for tsr_chain in tsr_chains):
+            SetTrajectoryTags(traj, {'constrained': 'true'}, append=True)
 
         # Strip extraneous groups from the output trajectory.
         # TODO: Where are these groups coming from!?

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -28,8 +28,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import contextlib, collections, logging, numpy, openravepy, rospkg, warnings
-import prpy.tsr
+import collections, logging, numpy, openravepy
+from .. import tsr
+from ..util import SetTrajectoryTags
 from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
 
 logger = logging.getLogger('prpy.planning.chomp')
@@ -257,8 +258,8 @@ class CHOMPPlanner(BasePlanner):
 
         return traj
 
+    # JK - Disabling. This is not working reliably.
     '''
-    JK - Disabling. This is not working reliably.
     @PlanningMethod
     def PlanToTSR(self, robot, tsrchains, lambda_=100.0, n_iter=100, goal_tolerance=0.01, **kw_args):
         """

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -28,15 +28,20 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import collections, logging, numpy, openravepy
+import collections
+import logging
+import numpy
+import openravepy
 from .. import tsr
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
+from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
+                  PlanningMethod)
 
 logger = logging.getLogger('prpy.planning.chomp')
 
 DistanceFieldKey = collections.namedtuple('DistanceFieldKey',
     [ 'kinematics_hash', 'enabled_mask', 'dof_values', 'dof_indices' ])
+
 
 class DistanceFieldManager(object):
     def __init__(self, module):
@@ -133,12 +138,15 @@ class DistanceFieldManager(object):
 
         return all_effected_links
 
+
 class CHOMPPlanner(BasePlanner):
     def __init__(self):
         super(CHOMPPlanner, self).__init__()
         self.setupEnv(self.env)
 
     def setupEnv(self, env):
+        from types import MethodType
+
         self.env = env
         try:
             from orcdchomp import orcdchomp
@@ -146,38 +154,46 @@ class CHOMPPlanner(BasePlanner):
         except ImportError:
             raise UnsupportedPlanningError('Unable to import orcdchomp.')
         except openravepy.openrave_exception as e:
-            raise UnsupportedPlanningError('Unable to create orcdchomp module: %s' % e)
+            raise UnsupportedPlanningError(
+                'Unable to create orcdchomp module: ' + str(e))
 
         if module is None:
-            raise UnsupportedPlanningError('Failed loading module.')
-        self.initialized = False
-        #orcdchomp.bind(self.module)
+            raise UnsupportedPlanningError('Failed loading CHOMP module.')
 
-        class Object():
+        # This is a hack to prevent leaking memory.
+        class CHOMPBindings(object):
             pass
 
-        import types
-
-        self.module = Object()
+        self.module = CHOMPBindings()
         self.module.module = module
-        self.module.viewspheres = types.MethodType(orcdchomp.viewspheres,module)
-        self.module.computedistancefield = types.MethodType(orcdchomp.computedistancefield,module)
-        self.module.addfield_fromobsarray = types.MethodType(orcdchomp.addfield_fromobsarray,module)
-        self.module.removefield = types.MethodType(orcdchomp.removefield,module)
-        self.module.create = types.MethodType(orcdchomp.create,module)
-        self.module.iterate = types.MethodType(orcdchomp.iterate,module)
-        self.module.gettraj = types.MethodType(orcdchomp.gettraj,module)
-        self.module.destroy = types.MethodType(orcdchomp.destroy,module)
-        self.module.runchomp = types.MethodType(orcdchomp.runchomp,module)
+        self.module.viewspheres =\
+            MethodType(orcdchomp.viewspheres, module)
+        self.module.computedistancefield =\
+            MethodType(orcdchomp.computedistancefield, module)
+        self.module.addfield_fromobsarray =\
+            MethodType(orcdchomp.addfield_fromobsarray, module)
+        self.module.removefield = MethodType(orcdchomp.removefield, module)
+        self.module.create = MethodType(orcdchomp.create, module)
+        self.module.iterate = MethodType(orcdchomp.iterate, module)
+        self.module.gettraj = MethodType(orcdchomp.gettraj, module)
+        self.module.destroy = MethodType(orcdchomp.destroy, module)
+        self.module.runchomp = MethodType(orcdchomp.runchomp, module)
         self.module.GetEnv = self.module.module.GetEnv
 
+        # Create a DistanceFieldManager to track which distance fields are
+        # currently loaded.
         self.distance_fields = DistanceFieldManager(self.module)
 
     def __str__(self):
         return 'CHOMP'
 
+    def ComputeDistanceField(self, robot):
+        logger.warning('ComputeDistanceField is deprecated. Distance fields are'
+                       ' now implicity created by DistanceFieldManager.')
+
     @PlanningMethod
-    def OptimizeTrajectory(self, robot, traj, lambda_=100.0, n_iter=50, **kw_args):
+    def OptimizeTrajectory(self, robot, traj, lambda_=100.0, n_iter=50,
+                           **kw_args):
         self.distance_fields.sync(robot)
 
         cspec = traj.GetConfigurationSpecification()
@@ -197,7 +213,8 @@ class CHOMPPlanner(BasePlanner):
             raise PlanningError(str(e))
 
     @PlanningMethod
-    def PlanToConfiguration(self, robot, goal, lambda_=100.0, n_iter=15, **kw_args):
+    def PlanToConfiguration(self, robot, goal, lambda_=100.0, n_iter=15,
+                            **kw_args):
         """
         Plan to a single configuration with single-goal CHOMP.
         @param robot
@@ -215,7 +232,8 @@ class CHOMPPlanner(BasePlanner):
             raise PlanningError(str(e))
 
     @PlanningMethod
-    def PlanToEndEffectorPose(self, robot, goal_pose, lambda_=100.0, n_iter=100, goal_tolerance=0.01, **kw_args):
+    def PlanToEndEffectorPose(self, robot, goal_pose, lambda_=100.0,
+                              n_iter=100, goal_tolerance=0.01, **kw_args):
         """
         Plan to a desired end-effector pose using GSCHOMP
         @param robot
@@ -235,11 +253,13 @@ class CHOMPPlanner(BasePlanner):
         start_config = robot.GetActiveDOFValues()
 
         try:
-            traj = self.module.runchomp(robot=robot, adofgoal=start_config, start_tsr=goal_tsr,
-                                        lambda_=lambda_, n_iter=n_iter, goal_tolerance=goal_tolerance,
-                                        releasegil=True, **kw_args)
+            traj = self.module.runchomp(
+                robot=robot, adofgoal=start_config, start_tsr=goal_tsr,
+                lambda_=lambda_, n_iter=n_iter, goal_tolerance=goal_tolerance,
+                releasegil=True, **kw_args
+            )
             traj = openravepy.planningutils.ReverseTrajectory(traj)
-        except RuntimeError, e:
+        except RuntimeError as e:
             raise PlanningError(str(e))
 
         # Verify that CHOMP didn't converge to the wrong goal. This is a
@@ -247,21 +267,26 @@ class CHOMPPlanner(BasePlanner):
         # fails because of joint limits.
         config_spec = traj.GetConfigurationSpecification()
         last_waypoint = traj.GetWaypoint(traj.GetNumWaypoints() - 1)
-        final_config = config_spec.ExtractJointValues(last_waypoint, robot, robot.GetActiveDOFIndices())
+        final_config = config_spec.ExtractJointValues(
+                last_waypoint, robot, robot.GetActiveDOFIndices())
         robot.SetActiveDOFValues(final_config)
         final_pose = robot.GetActiveManipulator().GetEndEffectorTransform()
 
         # TODO: Also check the orientation.
-        goal_distance = numpy.linalg.norm(final_pose[0:3, 3] - goal_pose[0:3, 3])
+        goal_distance = numpy.linalg.norm(final_pose[0:3, 3]
+                                         - goal_pose[0:3, 3])
         if goal_distance > goal_tolerance:
-            raise PlanningError('CHOMP deviated from the goal pose by {0:f} meters.'.format(goal_distance))
+            raise PlanningError(
+                'CHOMP deviated from the goal pose by {0:f} meters.'.format(
+                    goal_distance))
 
         return traj
 
     # JK - Disabling. This is not working reliably.
     '''
     @PlanningMethod
-    def PlanToTSR(self, robot, tsrchains, lambda_=100.0, n_iter=100, goal_tolerance=0.01, **kw_args):
+    def PlanToTSR(self, robot, tsrchains, lambda_=100.0, n_iter=100,
+                  goal_tolerance=0.01, **kw_args):
         """
         Plan to a goal TSR.
         @param robot
@@ -278,23 +303,19 @@ class CHOMPPlanner(BasePlanner):
         
         tsrchain = tsrchains[0]
         if not tsrchain.sample_goal or len(tsrchain.TSRs) > 1:
-            raise UnsupportedPlanningError('CHOMP: TSR chain must contain a single goal tsr')
+            raise UnsupportedPlanningError(
+                'CHOMP only supports TSR chains that contain a single goal'
+                ' TSR.'
+            )
         
         try:
             goal_tsr = tsrchain.TSRs[0]
-            traj = self.module.runchomp(robot=robot, adofgoal=start_config, start_tsr=goal_tsr,
-                                        lambda_=lambda_, n_iter=n_iter, goal_tolerance=goal_tolerance,
-                                        releasegil=True, **kw_args)
-
-            traj = openravepy.planningutils.ReverseTrajectory(traj)
-
-        except RuntimeError, e:
+            traj = self.module.runchomp(
+                robot=robot, adofgoal=start_config, start_tsr=goal_tsr,
+                lambda_=lambda_, n_iter=n_iter, goal_tolerance=goal_tolerance,
+                releasegil=True, **kw_args
+            )
+            return openravepy.planningutils.ReverseTrajectory(traj)
+        except RuntimeError as e:
             raise PlanningError(str(e))
-
-        return traj
     '''
-
-    def ComputeDistanceField(self, robot):
-        logger.warning('ComputeDistanceField is deprecated. Distance fields are'
-                       ' now implicity created by DistanceFieldManager.')
-

--- a/src/prpy/planning/mac_smoother.py
+++ b/src/prpy/planning/mac_smoother.py
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from ..util import CopyTrajectory, SimplifyTrajectory
+from ..util import CopyTrajectory, SimplifyTrajectory, SetTrajectoryTags
 from base import BasePlanner, PlanningError, PlanningMethod, UnsupportedPlanningError
 from openravepy import Planner, PlannerStatus, RaveCreatePlanner, openrave_exception
 
@@ -84,5 +84,6 @@ class MacSmoother(BasePlanner):
         except openrave_exception as e:
             raise PlanningError('Timing trajectory failed: ' + str(e))
 
+        SetTrajectoryTags(output_traj, {'optimized': 'true'}, append=True)
         return output_traj
 

--- a/src/prpy/planning/mk.py
+++ b/src/prpy/planning/mk.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import logging, numpy, openravepy, time
+from ..util import SetTrajectoryTags
 from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
 
 logger = logging.getLogger('planning')
@@ -216,4 +217,5 @@ class MKPlanner(BasePlanner):
                     logger.warning('Terminated early at distance %f < %f: %s',
                                    current_distance, max_distance, e.message)
 
+        SetTrajectoryTags(output_traj, {'constrained': 'true'}, append=True)
         return traj

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -29,7 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import logging, numpy, openravepy, os, tempfile
-from ..util import CopyTrajectory
+from ..util import CopyTrajectory, SetTrajectoryTags
 from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
 from openravepy import PlannerStatus 
 
@@ -214,4 +214,5 @@ class OMPLSimplifier(BasePlanner):
             raise PlanningError('Simplifier returned with status {0:s}.'.format(
                                 str(status)))
 
+        SetTrajectoryTags(output_path, {'optimized': 'true'}, append=True)
         return output_path

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import numpy
 import openravepy
+from ..util import SetTrajectoryTags
 from base import BasePlanner, PlanningError, PlanningMethod
 
 class SnapPlanner(BasePlanner):
@@ -128,4 +129,6 @@ class SnapPlanner(BasePlanner):
 
         traj.Init(cspec)
         traj.Insert(0, waypoints.ravel())
+
+        SetTrajectoryTags(traj, {'optimized': 'true'}, append=True)
         return traj

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -33,6 +33,7 @@ import logging
 import numpy
 import openravepy
 import time
+from ..util import SetTrajectoryTags
 from base import BasePlanner, PlanningError, PlanningMethod
 
 logger = logging.getLogger('planning')
@@ -221,4 +222,5 @@ class GreedyIKPlanner(BasePlanner):
                                    t, traj.GetDuration(), e.message)
 
         # Return as much of the trajectory as we have solved.
+        SetTrajectoryTags(qtraj, {'constrained': 'true'}, append=True)
         return qtraj

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -227,27 +227,14 @@ def GetTrajectoryTags(traj):
     @param traj input trajectory
     @return dictionary of string key/value pairs
     """
-    from collections import OrderedDict
-    import lxml.etree
-
-    tags = OrderedDict()
+    import json
 
     description = traj.GetDescription()
-    if not description:
-        return tags
 
-    root_ele = lxml.etree.fromstring(description)
-
-    for tag_ele in root_ele.getchildren():
-        key = tag_ele.get('key')
-        value = tag_ele.get('value')
-
-        if key is not None and value is not None:
-            tags[key] = value
-        else:
-            raise ValueError('<tag> element is missing key or value.')
-
-    return tags
+    if description:
+        return json.loads(description)
+    else:
+        return dict()
 
 
 def SetTrajectoryTags(traj, tags, append=False):
@@ -256,12 +243,12 @@ def SetTrajectoryTags(traj, tags, append=False):
     If append = True, then the dictionary of tags is added to any existing tags
     on the trajectory. Otherwise, all existing tags will be replaced. This
     metadata can be accessed by GetTrajectoryTags. Currently, the metadata is
-    stored as XML in the trajectory's description.
+    stored as JSON in the trajectory's description.
 
     @param traj input trajectory
     @param append if true, retain existing tags on the trajectory
     """
-    import lxml.etree
+    import json
 
     if append:
         all_tags = GetTrajectoryTags(traj)
@@ -269,16 +256,7 @@ def SetTrajectoryTags(traj, tags, append=False):
     else:
         all_tags = tags
 
-    root_ele = lxml.etree.Element(_tag='tags')
-
-    for key, value in all_tags.iteritems():
-        lxml.etree.SubElement(
-            _parent=root_ele, _tag='tag',
-            attrib={'key': key, 'value': value}
-        )
-
-    description = lxml.etree.tostring(root_ele)
-    traj.SetDescription(description)
+    traj.SetDescription(json.dumps(all_tags))
 
 
 def SimplifyTrajectory(traj, robot):


### PR DESCRIPTION
This pull request adds the `GetTrajectoryTags` and `SetTrajectoryTags` functions to `prpy.util`. These functions attach an arbitrary dictionary of string key/value pairs to a trajectory by serializing it to XML and storing it the trajectory's description. This data is cloned and serialized/deserialized along with the trajectory object.

I use these functions to tag trajectories with metadata in planners. The motivation is to use these tags to control what type of shorcutting, smoothing, and/or timing should be applied to the trajectory before execution.

This is roughly the logic I am implementing in an upcoming pull request:

- `constrained`, e.g. `PlanToEndEffectorOffset` or `PlanToTSR` with a constraint TSR
    - the trajectory was planned to obey a constraint
    - do not smooth the piecewise linear path during post-processing (i.e. do not stop at waypoints)
- `optimized`, e.g. CHOMP or TrajOpt
   - the trajectory optimizes a cost function
   - treat the trajectory as a continuous function during retiming (i.e. do not stop at waypoints)
- nothing e.g. `PlanToConfiguration` from an RRT
   - shortcut the trajectory and smooth it during retiming (i.e. change the path)

The `@PlanningMethod` decorator also tags all trajectories with two attributes:

- `planner_name`: name of the planner that returned the trajectory (e.g. `OMPLPlanner`)
- `planning_method`: name of the method that returned the trajectory (e.g. `PlanToConfiguration`)

This can be used to implement any arbitrary, complicated rules that occasionally appear. For example, we may want to retain the timing on the output of `PlanToEndEffectorOffset` on `VectorFieldPlanner`, but not on `PlanToEndEffectorOffset` on CBiRRT.

@siddhss5 @jeking04 @cdellin @psigen Thoughts?