### PR TITLE
Cleaned up CloneBindings functions

### DIFF
--- a/src/prpy/base/endeffector.py
+++ b/src/prpy/base/endeffector.py
@@ -37,8 +37,9 @@ class EndEffector(openravepy.Robot.Link):
 
     def CloneBindings(self, parent):
         from ..clone import Cloned
-        EndEffector.__init__(self, Cloned(parent.manipulator,
-                                          into=self.GetParent().GetEnv()))
+
+        self.manipulator = Cloned(parent.manipulator,
+                                  into=self.GetParent().GetEnv())
 
     def GetIndices(self):
         """Gets the DOF indicies associated with this end-effector.

--- a/src/prpy/base/manipulator.py
+++ b/src/prpy/base/manipulator.py
@@ -36,6 +36,9 @@ class Manipulator(openravepy.Robot.Manipulator):
     def __init__(self):
         pass
 
+    def CloneBindings(self, parent):
+        pass
+
     def __dir__(self):
         # We have to manually perform a lookup in InstanceDeduplicator because
         # __methods__ bypass __getattribute__.
@@ -62,9 +65,6 @@ class Manipulator(openravepy.Robot.Manipulator):
             return wrapper_method
 
         raise AttributeError('{0:s} is missing method "{1:s}".'.format(repr(self), name))
-
-    def CloneBindings(self, parent):
-        Manipulator.__init__(self)
 
     def GetIndices(self):
         """Gets the DOF indicies associated with this manipulaor.

--- a/src/prpy/simulation/servo.py
+++ b/src/prpy/simulation/servo.py
@@ -33,6 +33,7 @@ import atexit, logging, numpy, openravepy, threading, time
 class ServoSimulator(object):
     def __init__(self, manip, rate, watchdog_timeout):
         self.manip = manip
+
         # enabling threading and the following lines causes robot (and hence 
         # the environment) to not be garbage collected. It seems that threading
         # somehow blocks self.robot from being garbage collected


### PR DESCRIPTION
@psigen caught a memory leak when cloning in PrPy. At least on HERB, this was caused by a circular reference created by the `ServoSimulator` in cloned environments. This made me realize that we're currently cloning a lot of things that are never used in cloned environments (e.g. controllers, simulators, some planners).

This pull request cleans up all of the `CloneBindings` functions in PrPy that are used on HERB:

- Reference the TSRLibrary from the parent environment.
- Reference the NamedConfigurations from the parent environment.
- Don't load ServoSimulatored in cloned environments.
- Don't load any controllers in cloned environments.
- Avoid calling `__init__` to prevent future nasty surprises.
