### PR TITLE
feature added to avoid joint limit with ComputeJointVelocityFromTwist

### DIFF
--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -488,6 +488,8 @@ def ComputeJointVelocityFromTwist(robot, twist,
             defaults to quadraticObjective
     @params dq_init optional initial guess for optimal joint velocity
             defaults to robot.GetActiveDOFVelocities()
+    @params joint_limit_tolerance if less then this distance to joint
+            limit, velocity is bounded in that direction to 0
     @return dq_opt optimal joint velocity
     @return twist_opt actual achieved twist
             can be different from desired twist due to constraints


### PR DESCRIPTION
Added a new objective function, to be used for ComputeJointVelocityFromTwist, which adds a cost and gradient to avoid joint limits. Also modified ComputeJointVelocityFromTwist in order to make it have a hard constraint near a limit (was previously hard constrained at 0, now constrained at whatever joint_limit_tolerance is)