### PR TITLE
Added new MethodMask and FirstSupported meta-planners

### DIFF
--- a/src/prpy/planning/__init__.py
+++ b/src/prpy/planning/__init__.py
@@ -29,8 +29,8 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from base import (
-    Fallback,
-    Only,
+    FirstSupported,
+    MethodMask,
     Planner,
     PlanningError,
     Ranked,

--- a/src/prpy/planning/__init__.py
+++ b/src/prpy/planning/__init__.py
@@ -28,7 +28,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from base import PlanningError, UnsupportedPlanningError, Planner, Sequence, Ranked
+from base import (
+    Fallback,
+    Only,
+    Planner,
+    PlanningError,
+    Ranked,
+    Sequence,
+    UnsupportedPlanningError,
+)
 from chomp import CHOMPPlanner
 from cbirrt import CBiRRTPlanner
 from ompl import OMPLPlanner

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -38,6 +38,11 @@ from ..util import CopyTrajectory, GetTrajectoryTags, SetTrajectoryTags
 logger = logging.getLogger('planning')
 
 
+class Tags(object):
+    SMOOTH = 'smooth'
+    CONSTRAINED = 'constrained'
+
+
 class PlanningError(Exception):
     pass
 

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -318,7 +318,7 @@ class Ranked(MetaPlanner):
         raise MetaPlanningError("All planners failed.",
                                 dict(zip(all_planners, results)))
 
-class Fallback(MetaPlanner):
+class FirstSupported(MetaPlanner):
     def __init__(self, *planners):
         self._planners = planners
 
@@ -342,7 +342,7 @@ class Fallback(MetaPlanner):
         raise UnsupportedPlanningError()
 
 
-class Only(MetaPlanner):
+class MethodMask(MetaPlanner):
     def __init__(self, planner, methods):
         self._methods = set(methods)
         self._planner = planner

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -314,3 +314,50 @@ class Ranked(MetaPlanner):
 
         raise MetaPlanningError("All planners failed.",
                                 dict(zip(all_planners, results)))
+
+class Fallback(MetaPlanner):
+    def __init__(self, *planners):
+        self._planners = planners
+
+    def __str__(self):
+        return 'Fallback({:s})'.format(', '.join(map(str, self._planners)))
+
+    def get_planners(self, method_name):
+        return [planner for planner in self._planners
+                if hasattr(planner, method_name)]
+
+    def plan(self, method, args, kw_args):
+        for planner in self._planners:
+            if planner.has_planning_method(method):
+                plan_fn = getattr(planner, method)
+
+                try:
+                    return plan_fn(*args, **kw_args)
+                except UnsupportedPlanningError:
+                    continue
+
+        raise UnsupportedPlanningError()
+
+
+class Only(MetaPlanner):
+    def __init__(self, planner, methods):
+        self._methods = set(methods)
+        self._planner = planner
+        self._planners = [planner]
+
+    def __str__(self):
+        return 'Only({:s}, methods={:s})'.format(
+            self._planner, list(self._methods))
+
+    def get_planners(self, method_name):
+        if method_name in self._methods:
+            return [self._planner]
+        else:
+            return []
+
+    def plan(self, method, args, kw_args):
+        if method_name in self._methods:
+            plan_fn = getattr(self._planner, method)
+            return plan_fn(*args, **kw_args)
+        else:
+            raise UnsupportedPlanningError()

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -80,8 +80,6 @@ class PlanningMethod(object):
                     SetTrajectoryTags(planner_traj, tags, append=False)
 
                     return CopyTrajectory(planner_traj, env=env)
-
-                    return copied_traj
                 finally:
                     cloned_env.Unlock()
 

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -356,7 +356,7 @@ class Only(MetaPlanner):
             return []
 
     def plan(self, method, args, kw_args):
-        if method_name in self._methods:
+        if method in self._methods:
             plan_fn = getattr(self._planner, method)
             return plan_fn(*args, **kw_args)
         else:

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -30,7 +30,8 @@
 
 import copy, logging, numpy, openravepy, os, tempfile
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
+from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
+                  PlanningMethod, Tags)
 import prpy.kin, prpy.tsr
 
 class CBiRRTPlanner(BasePlanner):
@@ -256,7 +257,7 @@ class CBiRRTPlanner(BasePlanner):
 
         # Tag the trajectory as constrained if a constraint TSR is present.
         if any(tsr_chain.constrain for tsr_chain in tsr_chains):
-            SetTrajectoryTags(traj, {'constrained': 'true'}, append=True)
+            SetTrajectoryTags(traj, {Tags.CONSTRAINED: True}, append=True)
 
         # Strip extraneous groups from the output trajectory.
         # TODO: Where are these groups coming from!?

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -35,7 +35,7 @@ import openravepy
 from .. import tsr
 from ..util import SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
-                  PlanningMethod)
+                  PlanningMethod, Tags)
 
 logger = logging.getLogger('prpy.planning.chomp')
 
@@ -212,7 +212,7 @@ class CHOMPPlanner(BasePlanner):
         except Exception as e:
             raise PlanningError(str(e))
 
-        SetTrajectoryTags(traj, {'optimized': 'true'}, append=True)
+        SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
         return traj
 
     @PlanningMethod
@@ -234,7 +234,7 @@ class CHOMPPlanner(BasePlanner):
         except Exception as e:
             raise PlanningError(str(e))
 
-        SetTrajectoryTags(traj, {'optimized': 'true'}, append=True)
+        SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
         return traj
 
     @PlanningMethod
@@ -286,7 +286,7 @@ class CHOMPPlanner(BasePlanner):
                 'CHOMP deviated from the goal pose by {0:f} meters.'.format(
                     goal_distance))
 
-        SetTrajectoryTags(traj, {'optimized': 'true'}, append=True)
+        SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
         return traj
 
     # JK - Disabling. This is not working reliably.

--- a/src/prpy/planning/mac_smoother.py
+++ b/src/prpy/planning/mac_smoother.py
@@ -29,8 +29,10 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 from ..util import CopyTrajectory, SimplifyTrajectory, SetTrajectoryTags
-from base import BasePlanner, PlanningError, PlanningMethod, UnsupportedPlanningError
-from openravepy import Planner, PlannerStatus, RaveCreatePlanner, openrave_exception
+from base import (BasePlanner, PlanningError, PlanningMethod,
+                  UnsupportedPlanningError, Tags)
+from openravepy import (Planner, PlannerStatus, RaveCreatePlanner,
+                        openrave_exception)
 
 
 class MacSmoother(BasePlanner):
@@ -84,6 +86,6 @@ class MacSmoother(BasePlanner):
         except openrave_exception as e:
             raise PlanningError('Timing trajectory failed: ' + str(e))
 
-        SetTrajectoryTags(output_traj, {'optimized': 'true'}, append=True)
+        SetTrajectoryTags(output_traj, {Tags.SMOOTH: True}, append=True)
         return output_traj
 

--- a/src/prpy/planning/mk.py
+++ b/src/prpy/planning/mk.py
@@ -30,7 +30,8 @@
 
 import logging, numpy, openravepy, time
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
+from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
+                  PlanningMethod, Tags)
 
 logger = logging.getLogger('planning')
 
@@ -217,5 +218,6 @@ class MKPlanner(BasePlanner):
                     logger.warning('Terminated early at distance %f < %f: %s',
                                    current_distance, max_distance, e.message)
 
-        SetTrajectoryTags(output_traj, {'constrained': 'true'}, append=True)
+        SetTrajectoryTags(output_traj, {Tags.CONSTRAINED: True}, append=True)
         return traj
+

--- a/src/prpy/planning/named.py
+++ b/src/prpy/planning/named.py
@@ -31,17 +31,25 @@ import logging, numpy, openravepy
 from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
 
 class NamedPlanner(BasePlanner):
-    def __init__(self):
+    def __init__(self, delegate_planner=None):
+        """
+        @param delegate_planner planner used for PlanToConfiguration
+        """
         super(NamedPlanner, self).__init__()
+        self.delegate_planner = delegate_planner
 
     def __str__(self):
-        return 'NamedConfigurationPlanner'
+        return 'NamedPlanner'
 
     @PlanningMethod
     def PlanToNamedConfiguration(self, robot, name, **kw_args):
-        """
-        Plan this arm to saved configuration stored in robot.configurations by
-        ignoring any other DOFs specified in the named configuration.
+        """ Plan to a named configuration.
+
+        The configuration is looked up by name in robot.configurations. Any
+        DOFs not specified in the named configuration are ignored. Planning is
+        performed by PlanToConfiguration using a delegate planner. If not
+        specified, this defaults to robot.planner.
+
         @param name name of a saved configuration
         @param **kw_args optional arguments passed to PlanToConfiguration
         @returns traj trajectory
@@ -67,5 +75,6 @@ class NamedPlanner(BasePlanner):
                 arm_dof_values[i] = arm_dof_value
 
         # Delegate planning to another planner.
-        return robot.planner.PlanToConfiguration(robot, arm_dof_values, **kw_args)
+        planner = self.delegate_planner or robot.planner
+        return planner.PlanToConfiguration(robot, arm_dof_values, **kw_args)
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -30,7 +30,8 @@
 
 import logging, numpy, openravepy, os, tempfile
 from ..util import CopyTrajectory, SetTrajectoryTags
-from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
+from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
+                  PlanningMethod, Tags)
 from openravepy import PlannerStatus 
 
 logger = logging.getLogger('pypy.planning.ompl')
@@ -214,5 +215,5 @@ class OMPLSimplifier(BasePlanner):
             raise PlanningError('Simplifier returned with status {0:s}.'.format(
                                 str(status)))
 
-        SetTrajectoryTags(output_path, {'optimized': 'true'}, append=True)
+        SetTrajectoryTags(output_path, {Tags.SMOOTH: True}, append=True)
         return output_path

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -30,7 +30,7 @@
 import numpy
 import openravepy
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, PlanningMethod
+from base import BasePlanner, PlanningError, PlanningMethod, Tags
 
 class SnapPlanner(BasePlanner):
     """Planner that checks the straight-line trajectory to the goal.
@@ -130,5 +130,5 @@ class SnapPlanner(BasePlanner):
         traj.Init(cspec)
         traj.Insert(0, waypoints.ravel())
 
-        SetTrajectoryTags(traj, {'optimized': 'true'}, append=True)
+        SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
         return traj

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -46,6 +46,8 @@ class TSRPlanner(BasePlanner):
     def __str__(self):
         return 'TSRPlanner'
 
+    # TODO: Temporarily disabled based on Pras' feedback.
+    """
     @PlanningMethod
     def PlanToIK(self, robot, goal_pose, **kw_args):
         from ..tsr import TSR, TSRChain
@@ -54,6 +56,7 @@ class TSRPlanner(BasePlanner):
         tsr_chain = TSRChain(sample_goal=True, TSR=tsr)
 
         return self.PlanToTSR(robot, [tsr_chain], **kw_args)
+    """
 
     @PlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=2.0,

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -47,6 +47,15 @@ class TSRPlanner(BasePlanner):
         return 'TSRPlanner'
 
     @PlanningMethod
+    def PlanToIK(self, robot, goal_pose, **kw_args):
+        from ..tsr import TSR, TSRChain
+
+        tsr = TSR(T0_w=goal_pose, Tw_e=numpy.eye(4), Bw=numpy.zeros((6,2)))
+        tsr_chain = TSRChain(sample_goal=True, TSR=tsr)
+
+        return self.PlanToTSR(robot, [tsr_chain], **kw_args)
+
+    @PlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=2.0,
                   num_attempts=3, chunk_size=1, ranker=None,
                   max_deviation=2*numpy.pi, **kw_args):

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -33,7 +33,7 @@ import numpy
 import openravepy
 import time
 from .. import util
-from base import BasePlanner, PlanningError, PlanningMethod
+from base import BasePlanner, PlanningError, PlanningMethod, Tags
 from enum import Enum
 import math
 
@@ -97,7 +97,7 @@ class VectorFieldPlanner(BasePlanner):
 
         # Flag this trajectory as unconstrained. This overwrites the
         # constrained flag set by FollowVectorField.
-        util.SetTrajectoryTags(traj, {'constrained': 'false'}, append=True)
+        util.SetTrajectoryTags(traj, {Tags.CONSTRAINED: False}, append=True)
         return traj
 
     @PlanningMethod
@@ -263,9 +263,7 @@ class VectorFieldPlanner(BasePlanner):
             else:
                 raise
 
-        SetTrajectoryTags(qtraj, {
-            'constrained': 'true',
-            'timed': 'true'
-        }, append=True)
+        # TODO: Flag this trajectory as timed.
+        SetTrajectoryTags(qtraj, {Tags.CONSTRAINED: 'true'}, append=True)
 
         return qtraj

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -34,7 +34,7 @@ import numpy
 import openravepy
 import time
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, PlanningMethod
+from base import BasePlanner, PlanningError, PlanningMethod, Tags
 
 logger = logging.getLogger('planning')
 
@@ -222,5 +222,5 @@ class GreedyIKPlanner(BasePlanner):
                                    t, traj.GetDuration(), e.message)
 
         # Return as much of the trajectory as we have solved.
-        SetTrajectoryTags(qtraj, {'constrained': 'true'}, append=True)
+        SetTrajectoryTags(qtraj, {Tags.CONSTRAINED: True}, append=True)
         return qtraj


### PR DESCRIPTION
- Added the `FirstSupported` meta-planner. This meta-planner operates on a list of planners and calls the first planner in the list that supports the desired planning method.
- Added the `MethodMask` meta-planner. This meta-planner operates on a single planner by only allowing access to a subset of its planning methods.
- Added support for explicitly passing a delegate planner to:
    - IKPlanner
    - NamedPlanner
    - TSRPlanner
- Modified `TSRPlanne`r to raise an UnsupportedPlanningError when it receives unsupported TSRs. This is necessary to trigger the fallback behavior implemented in the Fallback meta-planner.
