### PR TITLE
Clear UserData in prpy.Clone

### DIFF
--- a/src/prpy/clone.py
+++ b/src/prpy/clone.py
@@ -83,6 +83,11 @@ class Clone(object):
 
         # Actually clone.
         with self.clone_env:
+            # Clear user-data. Otherwise, cloning into into the same target
+            # environment multiple times may not cause CloneBindings to get
+            # called again.
+            self.clone_env.SetUserData(None)
+
             if self.clone_env != self.clone_parent:
                 with self.clone_parent:
                     self.clone_env.Clone(self.clone_parent, self.options)


### PR DESCRIPTION
OpenRAVE's `Clone` function does not clear `UserData` on the target environment. We use `UserData` inside `InstanceDeduplicator` to associate objects between environments. This was causing us to only call `CloneBindings` the first time we clone into a target environment.

This should fix #111 and #114.

@Stefanos19 @jeking04: Can you try this and let me know?