### PR TITLE
Bugfix: IK GIL release

### DIFF
--- a/src/prpy/planning/ik.py
+++ b/src/prpy/planning/ik.py
@@ -62,7 +62,9 @@ class IKPlanner(BasePlanner):
             ik_param = IkParameterization(
                 goal_pose, IkParameterizationType.Transform6D)
             ik_solutions = manipulator.FindIKSolutions(
-                ik_param, IkFilterOptions.CheckEnvCollisions)
+                ik_param, IkFilterOptions.CheckEnvCollisions,
+                ikreturn=False, releasegil=True
+            )
 
         if ik_solutions.shape[0] == 0:
             raise PlanningError('There is no IK solution at the goal pose.')

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -87,7 +87,10 @@ class SnapPlanner(BasePlanner):
         manipulator = robot.GetActiveManipulator()
         current_config = robot.GetDOFValues(manipulator.GetArmIndices())
         ik_param = openravepy.IkParameterization(goal_pose, ikp.Transform6D)
-        ik_solution = manipulator.FindIKSolution(ik_param, ikfo.CheckEnvCollisions)
+        ik_solution = manipulator.FindIKSolution(
+            ik_param, ikfo.CheckEnvCollisions,
+            ikreturn=False, releasegil=True
+        )
 
         if ik_solution is None:
             raise PlanningError('There is no IK solution at the goal pose.')

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -101,7 +101,9 @@ class TSRPlanner(BasePlanner):
             ik_param = IkParameterization(
                 tsrchain.sample(), IkParameterizationType.Transform6D)
             ik_solution = manipulator.FindIKSolutions(
-                ik_param, IkFilterOptions.CheckEnvCollisions)
+                ik_param, IkFilterOptions.CheckEnvCollisions,
+                ikreturn=False, releasegil=True
+            )
             if ik_solution.shape[0] > 0:
                 ik_solutions.append(ik_solution)
 

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -182,7 +182,9 @@ class GreedyIKPlanner(BasePlanner):
                     qcurr = robot.GetActiveDOFValues()  # Configuration at t.
                     qnew = manip.FindIKSolution(
                         openravepy.matrixFromPose(traj.Sample(t+dt)[0:7]),
-                        ik_options
+                        ik_options,
+                        ikreturn=False,
+                        releasegil=True
                     )
 
                     # Check if the step was within joint DOF resolution.


### PR DESCRIPTION
This PR defaults FindIK calls in the planners to release the GIL while they execute.  This prevents thread locking during IK sampling.