### PR TITLE
Added more fine-grained planning exceptions

### DIFF
--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -34,6 +34,7 @@ import logging
 import openravepy
 from ..clone import Clone
 from ..util import CopyTrajectory, GetTrajectoryTags, SetTrajectoryTags
+from .exceptions import PlanningError, UnsupportedPlanningError
 
 logger = logging.getLogger('planning')
 
@@ -43,14 +44,6 @@ class Tags(object):
     CONSTRAINED = 'constrained'
     PLANNER = 'planner'
     METHOD = 'planning_method'
-
-class PlanningError(Exception):
-    pass
-
-
-class UnsupportedPlanningError(PlanningError):
-    pass
-
 
 class MetaPlanningError(PlanningError):
     def __init__(self, message, errors):

--- a/src/prpy/planning/exceptions.py
+++ b/src/prpy/planning/exceptions.py
@@ -1,0 +1,51 @@
+
+class PlanningError(Exception):
+    pass
+
+
+class UnsupportedPlanningError(PlanningError):
+    pass
+
+
+class ConstraintViolationPlanningError(PlanningError):
+    pass
+
+
+class CollisionPlanningError(PlanningError):
+    def __init__(self, link1, link2, base_message='Detected collision'):
+        self.link1 = link1
+        self.link2 = link2
+
+        super(CollisionPlanningError, self).__init__(
+            '{:s}: {:s} x {:s}.'.format(
+                base_message,
+                self._get_link_str(link1),
+                self._get_link_str(link2)
+            )
+        )
+
+    @classmethod
+    def FromReport(cls, report):
+        return cls(report.plink1, report.plink2)
+
+    @staticmethod
+    def _get_link_str(link):
+        if link is not None:
+            return '<{:s}, {:s}>'.format(
+                link.GetParent().GetName(), link.GetName())
+        else:
+            return '<unknown>'
+
+
+class SelfCollisionPlanningError(CollisionPlanningError):
+    pass
+
+
+class TimeoutPlanningError(PlanningError):
+    def __init__(self, timelimit=None):
+        if timelimit is not None:
+            message = 'Exceeded {:.3f} s time limit.'.format(timelimit)
+        else:
+            message = 'Exceeded time limit.'
+
+        super(TimeoutPlanningError, self).__init__(message)

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -152,6 +152,7 @@ class GreedyIKPlanner(BasePlanner):
         @param timelimit timeout in seconds
         @return qtraj configuration space path
         """
+        from .exceptions import TimeoutPlanningError
 
         with robot:
             manip = robot.GetActiveManipulator()
@@ -179,7 +180,7 @@ class GreedyIKPlanner(BasePlanner):
                     current_time = time.time()
                     if (timelimit is not None and
                             current_time - start_time > timelimit):
-                        raise PlanningError('Reached time limit.')
+                        raise TimeoutPlanningError(timelimit)
 
                     # Hypothesize new configuration as closest IK to current
                     qcurr = robot.GetActiveDOFValues()  # Configuration at t.


### PR DESCRIPTION
This is a first step towards #45.

I added a few subclasses to `PlanningError`. This includes a `CollisionPlanningError` that makes it easy to format a readable exception from a `CollisionReport` structure; e.g.

```
CollisionPlanningError: Terminated early: Detected collision: <table, table> x <herb, /right/finger2_2>.
```

For now, I only raise these exceptions in `GreedyIkPlanner` and `VectorFieldPlanner`. I likely missed many other places where we can throw a more specific exception.

@psigen @jeking04 @siddhss5 Thoughts?