### PR TITLE
Changed loggers to use '__name__' instead of explicit paths.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -39,7 +39,8 @@ from ..planning.retimer import HauserParabolicSmoother, OpenRAVEAffineRetimer, P
 from ..planning.mac_smoother import MacSmoother
 from ..util import SetTrajectoryTags
 
-logger = logging.getLogger('robot')
+logger = logging.getLogger(__name__)
+
 
 class Robot(openravepy.Robot):
     def __init__(self, robot_name=None):

--- a/src/prpy/bind.py
+++ b/src/prpy/bind.py
@@ -37,6 +37,7 @@ logger = logging.getLogger(__name__)
 class NotCloneableException(CloneException):
     pass
 
+
 class InstanceDeduplicator(object):
     USERDATA_PREFIX = 0xDEADBEEF
     USERDATA_CHILDREN = '__children__'
@@ -209,11 +210,11 @@ class InstanceDeduplicator(object):
             # skipped
             while children:
                 child = children.pop()
-                InstanceDeduplicator.logger.debug(child)
+                logger.debug(child)
                 clear_referrers(child)
                 # NOTE: this is also an acceptable body for the loop :)
                 # clear_referrers(children[0])
-            InstanceDeduplicator.logger.debug(owner)
+            logger.debug(owner)
             if canonical_instance != None:
                 clear_referrers(canonical_instance)
 
@@ -233,7 +234,7 @@ class InstanceDeduplicator(object):
                 handle = env.RegisterBodyCallback(InstanceDeduplicator.cleanup_callback)
                 user_data[cls.USERDATA_DESTRUCTOR] = handle
             else:
-                cls.logger.warning(
+                logger.warning(
                     'Your version of OpenRAVE does not supply Python bindings'
                     ' for Environment.RegisterBodyCallback. PrPy will leak'
                     ' unless you call prpy.bind.InstanceDeduplicator.remove_storage'

--- a/src/prpy/bind.py
+++ b/src/prpy/bind.py
@@ -31,13 +31,13 @@
 import logging
 from clone import CloneException
 
-logger = logging.getLogger('bind')
+logger = logging.getLogger(__name__)
+
 
 class NotCloneableException(CloneException):
     pass
 
 class InstanceDeduplicator(object):
-    logger = logging.getLogger('bind')
     USERDATA_PREFIX = 0xDEADBEEF
     USERDATA_CHILDREN = '__children__'
     USERDATA_DESTRUCTOR = '__destructor__'

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -36,7 +36,7 @@ from ..clone import Clone
 from ..util import CopyTrajectory, GetTrajectoryTags, SetTrajectoryTags
 from .exceptions import PlanningError, UnsupportedPlanningError
 
-logger = logging.getLogger('planning')
+logger = logging.getLogger(__name__)
 
 
 class Tags(object):
@@ -47,6 +47,7 @@ class Tags(object):
     PLAN_TIME = 'planning_time'
     POSTPROCESS_TIME = 'postprocess_time'
     EXECUTION_TIME = 'execution_time'
+
 
 class MetaPlanningError(PlanningError):
     def __init__(self, message, errors):

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -38,7 +38,7 @@ from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
                   PlanningMethod, Tags)
 import prpy.tsr
 
-logger = logging.getLogger('prpy.planning.chomp')
+logger = logging.getLogger(__name__)
 
 DistanceFieldKey = collections.namedtuple('DistanceFieldKey',
     [ 'kinematics_hash', 'enabled_mask', 'dof_values', 'dof_indices' ])

--- a/src/prpy/planning/ik.py
+++ b/src/prpy/planning/ik.py
@@ -35,7 +35,7 @@ from base import (BasePlanner,
                   PlanningError,
                   PlanningMethod)
 
-logger = logging.getLogger('prpy.planning.ik')
+logger = logging.getLogger(__name__)
 
 
 class IKPlanner(BasePlanner):

--- a/src/prpy/planning/mk.py
+++ b/src/prpy/planning/mk.py
@@ -33,7 +33,7 @@ from ..util import SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
                   PlanningMethod, Tags)
 
-logger = logging.getLogger('planning')
+logger = logging.getLogger(__name__)
 
 def DoNothing(robot):
     return numpy.zeros(robot.GetActiveDOF())

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -32,9 +32,9 @@ import logging, numpy, openravepy, os, tempfile
 from ..util import CopyTrajectory, SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
                   PlanningMethod, Tags)
-from openravepy import PlannerStatus 
+from openravepy import PlannerStatus
 
-logger = logging.getLogger('pypy.planning.ompl')
+logger = logging.getLogger(__name__)
 
 
 class OMPLPlanner(BasePlanner):

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -31,9 +31,10 @@
 import logging, numpy, openravepy, os, tempfile
 from ..util import CopyTrajectory, SimplifyTrajectory, HasAffineDOFs
 from base import BasePlanner, PlanningError, PlanningMethod, UnsupportedPlanningError
-from openravepy import PlannerStatus 
+from openravepy import PlannerStatus
 
-logger = logging.getLogger('retimer')
+logger = logging.getLogger(__name__)
+
 
 class OpenRAVERetimer(BasePlanner):
     def __init__(self, algorithm, default_options=None):

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -35,7 +35,7 @@ import openravepy
 from base import (BasePlanner, PlanningMethod, PlanningError,
                   UnsupportedPlanningError)
 
-logger = logging.getLogger('prpy.planning.tsr')
+logger = logging.getLogger(__name__)
 
 
 class TSRPlanner(BasePlanner):

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -37,7 +37,7 @@ from base import BasePlanner, PlanningError, PlanningMethod, Tags
 from enum import Enum
 import math
 
-logger = logging.getLogger('planning')
+logger = logging.getLogger(__name__)
 
 
 class Status(Enum):

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -36,7 +36,7 @@ import time
 from ..util import SetTrajectoryTags
 from base import BasePlanner, PlanningError, PlanningMethod, Tags
 
-logger = logging.getLogger('planning')
+logger = logging.getLogger(__name__)
 
 
 class GreedyIKPlanner(BasePlanner):

--- a/src/prpy/tsr/tsrlibrary.py
+++ b/src/prpy/tsr/tsrlibrary.py
@@ -31,7 +31,8 @@
 # -*- coding: utf-8 -*-
 import collections, functools, logging, numpy, os.path
 
-logger = logging.getLogger('tsr')
+logger = logging.getLogger(__name__)
+
 
 class TSRFactory(object):
     

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -33,7 +33,7 @@ import logging, numpy, openravepy, scipy.misc, time, threading, math
 import scipy.optimize
 
 
-logger = logging.getLogger('prpy.util')
+logger = logging.getLogger(__name__)
 
 
 def create_sensor(env, args, anonymous=True):


### PR DESCRIPTION
Since the predominant log convention was to use module name anyway,
it is simpler to simply dynamically query this instead of manually
specifying it each time.

This also fixes a number of typos and inconsistencies in the log
naming, due to the above.