### PR TITLE
Bugfix: cloning race condition

### DIFF
--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -79,14 +79,18 @@ class PlanningMethod(object):
             joint_values[1] = cloned_robot.GetActiveDOFValues()
 
             # Check for mismatches in the cloning and hackily reset them.
+            # (This is due to a possible bug in OpenRAVE environment cloning where in
+            # certain situations, the Active DOF ordering and values do not match the
+            # parent environment.  It seems to be exacerbated by multirotation joints,
+            # but the exact cause and repeatability is unclear at this point.)
             if not numpy.array_equal(joint_indices[0], joint_indices[1]):
-                logger.info("Cloned Active DOF index mismatch: %s != %s",
+                logger.warn("Cloned Active DOF index mismatch: %s != %s",
                             str(joint_indices[0]),
                             str(joint_indices[1]))
                 cloned_robot.SetActiveDOFs(joint_indices[0])
 
             if not numpy.allclose(joint_values[0], joint_values[1]):
-                logger.info("Cloned Active DOF value mismatch: %s != %s",
+                logger.warn("Cloned Active DOF value mismatch: %s != %s",
                             str(joint_values[0]),
                             str(joint_values[1]))
                 cloned_robot.SetActiveDOFValues(joint_values[0])

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -31,6 +31,7 @@
 import abc
 import functools
 import logging
+import numpy
 import openravepy
 from ..clone import Clone
 from ..util import CopyTrajectory, GetTrajectoryTags, SetTrajectoryTags
@@ -43,6 +44,7 @@ class Tags(object):
     CONSTRAINED = 'constrained'
     PLANNER = 'planner'
     METHOD = 'planning_method'
+
 
 class PlanningError(Exception):
     pass
@@ -68,9 +70,30 @@ class PlanningMethod(object):
         env = robot.GetEnv()
         defer = kw_args.get('defer')
 
+        # Store the original joint values and indices.
+        joint_indices = [robot.GetActiveDOFIndices(), None]
+        joint_values = [robot.GetActiveDOFValues(), None]
+
         with Clone(env, clone_env=instance.env,
                    lock=True, unlock=False) as cloned_env:
             cloned_robot = cloned_env.Cloned(robot)
+
+            # Store the cloned joint values and indices.
+            joint_indices[1] = cloned_robot.GetActiveDOFIndices()
+            joint_values[1] = cloned_robot.GetActiveDOFValues()
+
+            # Check for mismatches in the cloning and hackily reset them.
+            if not numpy.array_equal(joint_indices[0], joint_indices[1]):
+                logger.info("Cloned Active DOF index mismatch: %s != %s",
+                            str(joint_indices[0]),
+                            str(joint_indices[1]))
+                cloned_robot.SetActiveDOFs(joint_indices[0])
+
+            if not numpy.allclose(joint_values[0], joint_values[1]):
+                logger.info("Cloned Active DOF value mismatch: %s != %s",
+                            str(joint_values[0]),
+                            str(joint_values[1]))
+                cloned_robot.SetActiveDOFValues(joint_values[0])
 
             def call_planner():
                 try:

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -84,15 +84,15 @@ class PlanningMethod(object):
             # parent environment.  It seems to be exacerbated by multirotation joints,
             # but the exact cause and repeatability is unclear at this point.)
             if not numpy.array_equal(joint_indices[0], joint_indices[1]):
-                logger.warn("Cloned Active DOF index mismatch: %s != %s",
-                            str(joint_indices[0]),
-                            str(joint_indices[1]))
+                logger.warning("Cloned Active DOF index mismatch: %s != %s",
+                               str(joint_indices[0]),
+                               str(joint_indices[1]))
                 cloned_robot.SetActiveDOFs(joint_indices[0])
 
             if not numpy.allclose(joint_values[0], joint_values[1]):
-                logger.warn("Cloned Active DOF value mismatch: %s != %s",
-                            str(joint_values[0]),
-                            str(joint_values[1]))
+                logger.warning("Cloned Active DOF value mismatch: %s != %s",
+                               str(joint_values[0]),
+                               str(joint_values[1]))
                 cloned_robot.SetActiveDOFValues(joint_values[0])
 
             def call_planner():


### PR DESCRIPTION
This is a hotfix/patch for a bizarre race condition issue in which the cloned robot does not match the original robot while inside the cloning operation.  I really don't want to merge this, but I have no idea what could be causing this problem and it does happen semi-frequently.

Any ideas @mkoval @jeking04 ?