### PR TITLE
Changed default 'execute' behavior to False.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -570,7 +570,7 @@ class Robot(openravepy.Robot):
                 postprocess_trajectory(traj)
 
                 # Optionally execute the trajectory.
-                if kw_args.get('execute', True):
+                if kw_args.get('execute', False):
                     # We know defer = True if we're in this function, so we
                     # don't have to set it explicitly.
                     traj = yield trollius.From(
@@ -584,7 +584,7 @@ class Robot(openravepy.Robot):
             postprocess_trajectory(result)
 
             # Optionally execute the trajectory.
-            if kw_args.get('execute', True):
+            if kw_args.get('execute', False):
                 result = self.ExecutePath(result, **kw_args)
 
             return result


### PR DESCRIPTION
Currently, it is very scary that calling a Plan...() function anywhere in the code without 'execute=False' can cause a robot to start moving and doing things.

It does not seem at all reasonable that this is the default behavior, especially now that we are increasingly using pipelined planning calls and post processing trajectories heavily before execution in demos-- where execute=True is exactly the wrong thing to do.

We should not have to pass a non-default argument to every single planning call to keep the robot from moving.