### PR TITLE
Added support for environment (de)serialization

### DIFF
--- a/src/prpy/exceptions.py
+++ b/src/prpy/exceptions.py
@@ -17,3 +17,30 @@ class SynchronizationException(PrPyException):
     """
     Controller synchronization failed.
     """
+
+class SerializationException(PrPyException):
+    """
+    Serialization failed.
+    """
+
+class UnsupportedTypeSerializationException(SerializationException):
+    """
+    Serialization failed due to an unknown type.
+    """
+    def __init__(self, value):
+        self.value = value
+        self.type = type(self.value)
+
+        super(UnsupportedTypeSerializationException, self).__init__(
+            'Serializing type "{:s}.{:s}" is not supported.'.format(
+                self.type.__module__, self.type.__name__))
+
+class UnsupportedTypeDeserializationException(SerializationException):
+    """
+    Deserialization failed due to an unknown type.
+    """
+    def __init__(self, type_name):
+        self.type_name = type_name
+
+        super(UnsupportedTypeDeserializationException, self).__init__(
+            'Deserializing type "{:s}" is not supported.'.format(type_name))

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -41,7 +41,8 @@ logger = logging.getLogger('planning')
 class Tags(object):
     SMOOTH = 'smooth'
     CONSTRAINED = 'constrained'
-
+    PLANNER = 'planner'
+    METHOD = 'planning_method'
 
 class PlanningError(Exception):
     pass
@@ -80,8 +81,8 @@ class PlanningMethod(object):
                     # used to generate it. We don't overwrite these tags if
                     # they already exist.
                     tags = GetTrajectoryTags(planner_traj)
-                    tags.setdefault('planner', instance.__class__.__name__)
-                    tags.setdefault('planning_method', self.func.__name__)
+                    tags.setdefault(Tags.PLANNER, instance.__class__.__name__)
+                    tags.setdefault(Tags.METHOD, self.func.__name__)
                     SetTrajectoryTags(planner_traj, tags, append=False)
 
                     return CopyTrajectory(planner_traj, env=env)

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -141,7 +141,7 @@ class ParabolicSmoother(OpenRAVERetimer):
 
 class HauserParabolicSmoother(OpenRAVERetimer):
     def __init__(self, do_blend=True, do_shortcut=True, blend_radius=0.5,
-                 blend_iterations=4, **kwargs):
+                 blend_iterations=4, timelimit=-1, **kwargs):
         super(HauserParabolicSmoother, self).__init__(
                 'HauserParabolicSmoother', **kwargs)
 
@@ -150,6 +150,7 @@ class HauserParabolicSmoother(OpenRAVERetimer):
             'do_shortcut': int(do_shortcut),
             'blend_radius': float(blend_radius),
             'blend_iterations': int(blend_iterations),
+            'time_limit': float(timelimit),
         })
 
 

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -141,7 +141,7 @@ class ParabolicSmoother(OpenRAVERetimer):
 
 class HauserParabolicSmoother(OpenRAVERetimer):
     def __init__(self, do_blend=True, do_shortcut=True, blend_radius=0.5,
-                 blend_iterations=4, timelimit=-1, **kwargs):
+                 blend_iterations=0, timelimit=3., **kwargs):
         super(HauserParabolicSmoother, self).__init__(
                 'HauserParabolicSmoother', **kwargs)
 

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -44,7 +44,10 @@ class TSRPlanner(BasePlanner):
         self.delegate_planner = delegate_planner
 
     def __str__(self):
-        return 'TSRPlanner'
+        if self.delegate_planner is not None:
+            return 'TSRPlanner({:s})'.format(str(self.delegate_planner))
+        else:
+            return 'TSRPlanner'
 
     # TODO: Temporarily disabled based on Pras' feedback.
     """

--- a/src/prpy/serialization.py
+++ b/src/prpy/serialization.py
@@ -290,6 +290,10 @@ def deserialize_environment(data, env=None, purge=False, reuse_bodies=None):
         reuse_bodies_dict = { body.GetName(): body for body in reuse_bodies }
         reuse_bodies_set = set(reuse_bodies)
 
+    # Release anything that's grabbed.
+    for body in reuse_bodies:
+        body.ReleaseAllGrabbed()
+
     # Remove any extra bodies from the environment.
     for body in env.GetBodies():
         if body not in reuse_bodies_set:

--- a/src/prpy/serialization.py
+++ b/src/prpy/serialization.py
@@ -12,6 +12,7 @@ deserialization_logger = logging.getLogger('prpy.deserialization')
 def _serialize_internal(obj):
     from numpy import ndarray
     from openravepy import Environment, KinBody, Robot, Trajectory
+    from prpy.tsr import TSR, TSRChain
 
     NoneType = type(None)
 
@@ -34,6 +35,8 @@ def _serialize_internal(obj):
         }
     elif isinstance(obj, Trajectory):
         return { 'data': obj.serialize(0) }
+    elif isinstance(obj, (TSR, TSRChain)):
+        return { 'data': obj.serialize() }
     else:
         raise UnsupportedTypeSerializationException(obj)
 
@@ -224,7 +227,7 @@ def _deserialize_internal(env, data, data_type):
         traj.deserialize(data['data'])
         return traj
     else:
-        raise UnsupportedTypeDeserializationException(type_name)
+        raise UnsupportedTypeDeserializationException(data_type)
 
 def deserialize(env, data):
     if isinstance(data, unicode):

--- a/src/prpy/serialization.py
+++ b/src/prpy/serialization.py
@@ -1,0 +1,268 @@
+import numpy
+import openravepy
+
+# Serialization.
+def serialize_environment(env):
+    return {
+        'bodies': map(serialize_kinbody, env.GetBodies())
+    }
+
+def serialize_kinbody(body):
+    all_joints = []
+    all_joints.extend(body.GetJoints())
+    all_joints.extend(body.GetPassiveJoints())
+    all_joints.sort(key=lambda x: x.GetJointIndex())
+
+    return {
+        'name': body.GetName(),
+        'uri': body.GetXMLFilename(),
+        'links': map(serialize_link, body.GetLinks()),
+        'joints': map(serialize_joint, all_joints),
+        'state': serialize_kinbody_state(body),
+    }
+
+def serialize_kinbody_state(body):
+    return {
+        name: get_fn(body)
+        for name, (get_fn, _) in KINBODY_STATE_MAP.iteritems()
+    }
+
+def serialize_link(link):
+    return {
+        'info': serialize_link_info(link.GetInfo())
+    }
+
+def serialize_joint(joint):
+    return {
+        'info': serialize_joint_info(joint.GetInfo())
+    }
+
+def serialize_with_map(obj, attribute_map):
+    return {
+        key: serialize_fn(getattr(obj, key))
+        for key, (serialize_fn, _) in attribute_map.iteritems()
+    }
+
+def serialize_link_info(link_info):
+    return serialize_with_map(link_info, LINK_INFO_MAP)
+    
+def serialize_joint_info(joint_info):
+    return serialize_with_map(joint_info, JOINT_INFO_MAP)
+
+def serialize_manipulator_info(manip_info):
+    return serialize_with_map(manip_info, MANIPULATOR_INFO_MAP)
+
+def serialize_geometry_info(geom_info):
+    return serialize_with_map(geom_info, GEOMETRY_INFO_MAP)
+
+def serialize_transform(t):
+    from openravepy import quatFromRotationMatrix
+
+    return {
+        'position': list(t[0:3, 3]),
+        'orientation': list(quatFromRotationMatrix(t[0:3, 0:3])),
+    }
+
+# Deserialization.
+def deserialize_kinbody(env, data, name=None, anonymous=False):
+    from openravepy import RaveCreateKinBody
+
+    kinbody = RaveCreateKinBody(env, '')
+    kinbody.Init(
+        linkinfos=[
+            deserialize_link_info(link_data['info']) \
+            for link_data in data['links']
+        ],
+        jointinfos=[
+            deserialize_joint_info(joint_data['info']) \
+            for joint_data in data['joints']
+        ],
+        uri=data['uri'],
+    )
+
+    kinbody.SetName(name or data['name'])
+    env.Add(kinbody, anonymous)
+
+    deserialize_kinbody_state(kinbody, data['state'])
+
+    return kinbody
+
+def deserialize_kinbody_state(body, data):
+    for key, (_, set_fn) in KINBODY_STATE_MAP.iteritems():
+        set_fn(body, data[key])
+
+def deserialize_with_map(obj, data, attribute_map):
+    for key, (_, deserialize_fn) in attribute_map.iteritems():
+        setattr(obj, key, deserialize_fn(data[key]))
+
+    return obj
+
+def deserialize_link_info(data):
+    from openravepy import KinBody
+
+    return deserialize_with_map(KinBody.LinkInfo(), data, LINK_INFO_MAP)
+    
+def deserialize_joint_info(data):
+    from openravepy import KinBody
+
+    return deserialize_with_map(KinBody.JointInfo(), data, JOINT_INFO_MAP)
+
+def deserialize_manipulator_info(data):
+    from openravepy import Robot
+
+    return deserialize_with_map(Robot.ManipulatorInfo(), data, MANIPULATOR_INFO_MAP)
+
+def deserialize_geometry_info(data):
+    from openravepy import KinBody 
+
+    geom_info = deserialize_with_map(
+        KinBody.GeometryInfo(), data, GEOMETRY_INFO_MAP)
+
+    # OpenRAVE only has a ReadTrimeshURI method on Environment. We create a
+    # static, dummy environment (mesh_environment) just to load meshes.
+    if geom_info._filenamecollision:
+        geom_info._meshcollision = mesh_environment.ReadTrimeshURI(
+            geom_info._filenamecollision)
+
+    return geom_info
+
+def deserialize_transform(data):
+    from openravepy import matrixFromQuat
+
+    t = matrixFromQuat(data['orientation'])
+    t[0:3, 3] = data['position']
+    return t
+
+# Schema.
+mesh_environment = openravepy.Environment()
+identity = lambda x: x
+both_identity = (identity, identity)
+
+KINBODY_STATE_MAP = {
+    'description': (
+        lambda x: x.GetDescription(),
+        lambda x, value: x.SetDescription(value),
+    ),
+    'link_enable_states': (
+        lambda x: list(x.GetLinkEnableStates()),
+        lambda x, value: x.SetLinkEnableStates(value)
+    ),
+    'link_transforms': (
+        lambda x: map(serialize_transform, x.GetLinkTransformations()),
+        lambda x, value: x.SetLinkTransformations(
+            map(deserialize_transform, value)
+        ),
+    ),
+    'link_velocities': (
+        lambda x: x.GetLinkVelocities().tolist(),
+        lambda x, value: x.SetLinkVelocities(value),
+    ),
+    'transform': (
+        lambda x: serialize_transform(x.GetTransform()),
+        lambda x, value: x.SetTransform(deserialize_transform(value)),
+    ),
+    'dof_weights': (
+        lambda x: list(x.GetDOFWeights()),
+        lambda x, value: x.SetDOFWeights(value),
+    ),
+    'dof_resolutions': (
+        lambda x: list(x.GetDOFResolutions()),
+        lambda x, value: x.SetDOFResolutions(value),
+    ),
+    'dof_position_limits': (
+        lambda x: [ limits.tolist() for limits in x.GetDOFLimits() ],
+        lambda x, (lower, upper): x.SetDOFLimits(lower, upper),
+    ),
+    'dof_velocity_limits': (
+        lambda x: list(x.GetDOFVelocityLimits()),
+        lambda x, value: x.SetDOFVelocityLimits(value),
+    ),
+    'dof_acceleration_limits': (
+        lambda x: list(x.GetDOFAccelerationLimits()),
+        lambda x, value: x.SetDOFAccelerationLimits(value),
+    ),
+    'dof_torque_limits': (
+        lambda x: list(x.GetDOFTorqueLimits()),
+        lambda x, value: x.SetDOFTorqueLimits(value),
+    ),
+    # TODO: What about link accelerations and geometry groups?
+}
+LINK_INFO_MAP = {
+    '_bIsEnabled': both_identity,
+    '_bStatic': both_identity,
+    '_mapFloatParameters': both_identity,
+    '_mapIntParameters': both_identity,
+    '_mapStringParameters': both_identity,
+    '_mass': both_identity,
+    '_name': both_identity,
+    '_t': (serialize_transform, deserialize_transform),
+    '_tMassFrame': (serialize_transform, deserialize_transform),
+    '_vForcedAdjacentLinks': both_identity,
+    '_vgeometryinfos': (
+        lambda x: map(serialize_geometry_info, x),
+        lambda x: map(deserialize_geometry_info, x),
+    ),
+    '_vinertiamoments': (list, numpy.array),
+}
+JOINT_INFO_MAP = {
+    '_bIsActive': both_identity,
+    '_bIsCircular': both_identity,
+    '_linkname0': both_identity,
+    '_linkname1': both_identity,
+    '_mapFloatParameters': both_identity,
+    '_mapIntParameters': both_identity,
+    '_mapStringParameters': both_identity,
+    '_name': both_identity,
+    '_type': (
+        lambda x: x.name,
+        lambda x: openravepy.KinBody.JointType.names[x]
+    ),
+    '_vanchor': (list, numpy.array),
+    '_vaxes': (
+        lambda x: map(list, x),
+        lambda x: map(numpy.array, x)
+    ),
+    '_vcurrentvalues': (list, numpy.array),
+    '_vhardmaxvel': (list, numpy.array),
+    '_vlowerlimit': (list, numpy.array),
+    '_vmaxaccel': (list, numpy.array),
+    '_vmaxinertia': (list, numpy.array),
+    '_vmaxtorque': (list, numpy.array),
+    '_vmaxvel': (list, numpy.array),
+    '_vmimic': both_identity,
+    '_voffsets': (list, numpy.array),
+    '_vresolution': (list, numpy.array),
+    '_vupperlimit': (list, numpy.array),
+    '_vweights': (list, numpy.array),
+}
+GEOMETRY_INFO_MAP = {
+    '_bModifiable': both_identity,
+    '_bVisible': both_identity,
+    '_fTransparency': both_identity,
+    '_filenamecollision': both_identity,
+    '_filenamerender': both_identity,
+    '_t': (serialize_transform, deserialize_transform),
+    '_type': (
+        lambda x: x.name,
+        lambda x: openravepy.GeometryType.names[x]
+    ),
+    '_vAmbientColor': (list, numpy.array),
+    '_vCollisionScale': both_identity,
+    '_vDiffuseColor': (list, numpy.array),
+    '_vGeomData': (list, numpy.array),
+    '_vRenderScale': (list, numpy.array),
+    # TODO: What are these?
+    #'_mapExtraGeometries': None
+    #'_trajfollow': None,
+}
+MANIPULATOR_INFO_MAP = {
+    '_name': both_identity,
+    '_sBaseLinkName': both_identity,
+    '_sEffectorLinkName': both_identity,
+    '_sIkSolverXMLId': both_identity,
+    '_tLocalTool': (serialize_transform, deserialize_transform),
+    '_vChuckingDirection': (list, numpy.array),
+    '_vClosingDirection': (list, numpy.array),
+    '_vGripperJointNames': (list, numpy.array),
+    '_vdirection': (list, numpy.array),
+}

--- a/src/prpy/serialization.py
+++ b/src/prpy/serialization.py
@@ -36,7 +36,7 @@ def _serialize_internal(obj):
     elif isinstance(obj, Trajectory):
         return { 'data': obj.serialize(0) }
     elif isinstance(obj, (TSR, TSRChain)):
-        return { 'data': obj.serialize() }
+        return { 'data': obj.serialize_dict() }
     else:
         raise UnsupportedTypeSerializationException(obj)
 
@@ -166,6 +166,7 @@ def _deserialize_internal(env, data, data_type):
     from numpy import array, ndarray
     from openravepy import (Environment, KinBody, Robot, Trajectory,
                             RaveCreateTrajectory)
+    from prpy.tsr import TSR, TSRChain
     from .exceptions import UnsupportedTypeDeserializationException
 
     if data_type == dict.__name__:
@@ -226,6 +227,10 @@ def _deserialize_internal(env, data, data_type):
         traj = RaveCreateTrajectory(env, '')
         traj.deserialize(data['data'])
         return traj
+    elif data_type == TSR.__name__:
+        return TSR.deserialize_dict(data['data'])
+    elif data_type == TSRChain.__name__:
+        return TSRChain.deserialize_dict(data['data'])
     else:
         raise UnsupportedTypeDeserializationException(data_type)
 

--- a/src/prpy/tsr/tsr.py
+++ b/src/prpy/tsr/tsr.py
@@ -146,6 +146,24 @@ class TSR(object):  # force new-style class
                                    SerializeTransform12Col(self.Tw_e),
                                    SerializeArray(self.Bw))
 
+    def serialize_dict(self):
+        return {
+            'T0_w': self.T0_w.tolist(),
+            'Tw_e': self.Tw_e.tolist(),
+            'Bw': self.Bw.tolist(),
+            'manipindex': int(self.manipindex),
+            'bodyandlink': str(self.bodyandlink),
+        }
+
+    @staticmethod
+    def deserialize_dict(x):
+        return TSR(
+            T0_w = numpy.array(x['T0_w']),
+            Tw_e = numpy.array(x['Tw_e']),
+            Bw = numpy.array(x['Bw']),
+            manip = numpy.array(x['manipindex']),
+            bodyandlink = numpy.array(x['bodyandlink'])
+        )
 
 class TSRChain(object):
 
@@ -200,8 +218,29 @@ class TSRChain(object):
                                      SerializeArray(self.mimicbodyjoints))
         return outstring
 
-    def sample(self):
+    def serialize_dict(self):
+        return {
+            'sample_goal': self.sample_goal,
+            'sample_start': self.sample_start,
+            'constrain': self.constrain,
+            'mimicbodyname': self.mimicbodyname,
+            'mimicbodyjoints': self.mimicbodyjoints,
+            'tsrs': [ tsr.serialize_dict() for tsr in self.TSRs ],
+        }
 
+
+    @staticmethod
+    def deserialize_dict(x):
+        return TSRChain(
+            sample_start=x['sample_start'],
+            sample_goal=x['sample_goal'],
+            constrain=x['constrain'],
+            TSRs=[ TSR.deserialize_dict(tsr) for tsr in x['tsrs'] ],
+            mimicbodyname=x['mimicbodyname'],
+            mimicbodyjoints=x['mimicbodyjoints'],
+        )
+
+    def sample(self):
         if len(self.TSRs) == 0:
             return None
 


### PR DESCRIPTION
This pull request adds `serialize` and `deserialize` functions in the `prpy.serialization` module. These functions operate an an OpenRAVE environment by serializing to and deserializing from a `dict`. This `dict` only contains primitive types and be written to disk, e.g. using `pickle`, `json`, or `yaml`.