### PR TITLE
Changed GetDuration=0.0 error to warning.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -459,7 +459,10 @@ class Robot(openravepy.Robot):
 
         # Verify that the trajectory is timed.
         if traj.GetDuration() <= 0.0:
-            raise ValueError('Attempted to execute untimed trajectory.')
+            import warnings
+            warnings.warn('Executing zero-length trajectory. Please update the'
+                          ' function that produced this trajectory to return a'
+                          ' single-waypoint trajectory.', FutureWarning)
 
         # TODO: Check if this trajectory contains the base.
         needs_base = util.HasAffineDOFs(traj.GetConfigurationSpecification())

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -457,7 +457,13 @@ class Robot(openravepy.Robot):
             else:
                 return traj
 
-        # Verify that the trajectory is timed.
+        # Verify that the trajectory is timed by checking whether the first
+        # waypoint has a valid deltatime value.
+        cspec = traj.GetConfigurationSpecification()
+        if cspec.ExtractDeltaTime(traj.GetWaypoint(0)) is None:
+            raise ValueError('Trajectory cannot be executed, it is not timed.')
+
+        # Verify that the trajectory has non-zero duration.
         if traj.GetDuration() <= 0.0:
             import warnings
             warnings.warn('Executing zero-length trajectory. Please update the'


### PR DESCRIPTION
Currently, there are multiple non-compliant algorithms in the post-processing pipeline that generate multiple-waypoint zero-duration trajectories if given a single-waypoint trajectory.

We will need to keep this as a warning until they are updated.