### PR TITLE
Bugfix: SimplifyTrajectory calls in retimer

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -459,8 +459,7 @@ class Robot(openravepy.Robot):
 
         # Verify that the trajectory is timed by checking whether the first
         # waypoint has a valid deltatime value.
-        cspec = traj.GetConfigurationSpecification()
-        if cspec.ExtractDeltaTime(traj.GetWaypoint(0)) is None:
+        if not util.IsTimedTrajectory(traj):
             raise ValueError('Trajectory cannot be executed, it is not timed.')
 
         # Verify that the trajectory has non-zero duration.

--- a/src/prpy/planning/mac_smoother.py
+++ b/src/prpy/planning/mac_smoother.py
@@ -61,8 +61,7 @@ class MacSmoother(BasePlanner):
         # environment and/or (2) the retimer modifies the trajectory in-place.
         output_traj = CopyTrajectory(path, env=self.env)
 
-        # Remove co-linear waypoints. Some of the default OpenRAVE retimers do
-        # not perform this check internally (e.g. ParabolicTrajectoryRetimer).
+        # Remove co-linear waypoints.
         if not IsTimedTrajectory(output_traj):
             output_traj = SimplifyTrajectory(output_traj, robot)
 

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -32,9 +32,7 @@ import logging
 import openravepy
 from ..util import (CreatePlannerParametersString, CopyTrajectory,
                     SimplifyTrajectory, HasAffineDOFs, IsTimedTrajectory)
-from base import (BasePlanner,
-                  PlanningError,
-                  PlanningMethod,
+from base import (BasePlanner, PlanningError, PlanningMethod,
                   UnsupportedPlanningError)
 from openravepy import PlannerStatus, Planner
 

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -28,10 +28,15 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import logging, numpy, openravepy, os, tempfile
-from ..util import CopyTrajectory, SimplifyTrajectory, HasAffineDOFs
-from base import BasePlanner, PlanningError, PlanningMethod, UnsupportedPlanningError
-from openravepy import PlannerStatus
+import logging
+import openravepy
+from ..util import (CreatePlannerParametersString, CopyTrajectory,
+                    SimplifyTrajectory, HasAffineDOFs, IsTimedTrajectory)
+from base import (BasePlanner,
+                  PlanningError,
+                  PlanningMethod,
+                  UnsupportedPlanningError)
+from openravepy import PlannerStatus, Planner
 
 logger = logging.getLogger(__name__)
 
@@ -56,11 +61,8 @@ class OpenRAVERetimer(BasePlanner):
 
     @PlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kw_args):
-        from ..util import (CreatePlannerParametersString, CopyTrajectory,
-                            SimplifyTrajectory, HasAffineDOFs)
         from openravepy import CollisionOptions, CollisionOptionsStateSaver
         from copy import deepcopy
-        from openravepy import Planner
 
         # Validate the input path.
         cspec = path.GetConfigurationSpecification()
@@ -91,11 +93,12 @@ class OpenRAVERetimer(BasePlanner):
         # Copy the input trajectory into the planning environment. This is
         # necessary for two reasons: (1) the input trajectory may be in another
         # environment and/or (2) the retimer modifies the trajectory in-place.
-        input_path = CopyTrajectory(path, env=self.env)
+        output_traj = CopyTrajectory(path, env=self.env)
 
         # Remove co-linear waypoints. Some of the default OpenRAVE retimers do
         # not perform this check internally (e.g. ParabolicTrajectoryRetimer).
-        output_traj = SimplifyTrajectory(input_path, robot)
+        if not IsTimedTrajectory(output_traj):
+            output_traj = SimplifyTrajectory(output_traj, robot)
 
         # Only collision check the active DOFs.
         dof_indices, _ = cspec.ExtractUsedIndices(robot)
@@ -104,13 +107,12 @@ class OpenRAVERetimer(BasePlanner):
         # Compute the timing. This happens in-place.
         self.planner.InitPlan(None, params_str)
 
-
         with CollisionOptionsStateSaver(self.env.GetCollisionChecker(),
                                         CollisionOptions.ActiveDOFs):
             status = self.planner.PlanPath(output_traj, releasegil=True)
 
-        if status not in [ PlannerStatus.HasSolution,
-                           PlannerStatus.InterruptedWithSolution ]:
+        if status not in [PlannerStatus.HasSolution,
+                          PlannerStatus.InterruptedWithSolution]:
             raise PlanningError(
                 'Retimer returned with status {:s}.'.format(str(status)))
 
@@ -182,8 +184,6 @@ class OpenRAVEAffineRetimer(BasePlanner):
             if not found:
                 raise UnsupportedPlanningError('OpenRAVEAffineRetimer only supports untimed paths with affine DOFs. Found group: %s' % group.name)
 
-
-
         # Copy the input trajectory into the planning environment. This is
         # necessary for two reasons: (1) the input trajectory may be in another
         # environment and/or (2) the retimer modifies the trajectory in-place.
@@ -197,8 +197,8 @@ class OpenRAVEAffineRetimer(BasePlanner):
         status = RetimeTrajectory(output_traj, max_velocities, max_accelerations,
                                   False)
 
-        if status not in [ PlannerStatus.HasSolution,
-                           PlannerStatus.InterruptedWithSolution ]:
+        if status not in [PlannerStatus.HasSolution,
+                          PlannerStatus.InterruptedWithSolution]:
             raise PlanningError('Retimer returned with status {0:s}.'.format(
                                 str(status)))
 

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -735,3 +735,17 @@ def IsAtTrajectoryStart(robot, trajectory):
 
     # If all joints match, return True.
     return True
+
+
+def IsTimedTrajectory(trajectory):
+    """
+    Returns True if the trajectory is timed.
+
+    This function checks whether a trajectory has a valid `deltatime` group,
+    indicating that it is a timed trajectory.
+
+    @param trajectory: an OpenRAVE trajectory
+    @returns: True if the trajectory is timed, False otherwise
+    """
+    cspec = trajectory.GetConfigurationSpecification()
+    return cspec.ExtractDeltaTime(trajectory.GetWaypoint(0)) is not None


### PR DESCRIPTION
SimplifyTrajectory is very simple and can't safely reinterpolate timed trajectories.  This patch modifies the retimers to not call SimplifyTrajectory on already timed trajectories, since it will just throw an error and fail anyway.