### PR TITLE
Added termcolor dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -17,6 +17,7 @@
   <run_depend>manipulation2</run_depend>
   <run_depend>openrave</run_depend>
   <run_depend>python-scipy</run_depend>
+  <run_depend>python-termcolor</run_depend>
   <test_depend>python-nose</test_depend>
   <test_depend>unittest</test_depend>
 </package>


### PR DESCRIPTION
There is now a rosdep key for `termcolor`, so I added it to the `package.xml` file.

This fixes #150.