### PR TITLE
Add support for numpy <1.8 which don't support norm(axis=1)

### DIFF
--- a/src/prpy/__init__.py
+++ b/src/prpy/__init__.py
@@ -32,3 +32,4 @@ import base, dependency_manager, logger, ik_ranking, planning, simulation, tsr, 
 from named_config import ConfigurationLibrary
 from clone import Clone, Cloned
 from bind import bind_subclass
+import compatibility

--- a/src/prpy/compatibility.py
+++ b/src/prpy/compatibility.py
@@ -1,0 +1,14 @@
+from distutils.version import LooseVersion
+import numpy
+
+# handle older versions of numpy without norm axis argument
+if LooseVersion(numpy.__version__) < LooseVersion('1.8.0'):
+    oldnorm = numpy.linalg.norm
+    def newnorm(x, ord=None, axis=None):
+        if axis is None:
+            return oldnorm(x, ord=ord)
+        elif isinstance(axis, (int,long)):
+            return numpy.apply_along_axis(lambda x: oldnorm(x,ord=ord), axis, x)
+        else:
+            raise NotImplementedError('older numpy without norm axis')
+    numpy.linalg.norm = newnorm

--- a/src/prpy/ik_ranking.py
+++ b/src/prpy/ik_ranking.py
@@ -30,6 +30,7 @@
 
 import numpy
 
+
 def NoRanking(robot, ik_solutions):
     """
     Return IK solutions with an arbitrary ranking.

--- a/src/prpy/ik_ranking.py
+++ b/src/prpy/ik_ranking.py
@@ -28,20 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from distutils.version import LooseVersion
 import numpy
-
-# handle older versions of numpy without norm axis argument
-if LooseVersion(numpy.__version__) < LooseVersion('1.8.0'):
-    oldnorm = numpy.linalg.norm
-    def newnorm(x, ord=None, axis=None):
-        if axis is None:
-            return oldnorm(x, ord=ord)
-        elif isinstance(axis, (int,long)):
-            return numpy.apply_along_axis(oldnorm, axis, x)
-        else:
-            raise NotImplementedError('older numpy without norm axis')
-    numpy.linalg.norm = newnorm
 
 def NoRanking(robot, ik_solutions):
     """

--- a/src/prpy/ik_ranking.py
+++ b/src/prpy/ik_ranking.py
@@ -28,8 +28,20 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+from distutils.version import LooseVersion
 import numpy
 
+# handle older versions of numpy without norm axis argument
+if LooseVersion(numpy.__version__) < LooseVersion('1.8.0'):
+    oldnorm = numpy.linalg.norm
+    def newnorm(x, ord=None, axis=None):
+        if axis is None:
+            return oldnorm(x, ord=ord)
+        elif isinstance(axis, (int,long)):
+            return numpy.apply_along_axis(oldnorm, axis, x)
+        else:
+            raise NotImplementedError('older numpy without norm axis')
+    numpy.linalg.norm = newnorm
 
 def NoRanking(robot, ik_solutions):
     """


### PR DESCRIPTION
Numpy 1.8, released in October 2013, added an optional `axis` argument to `numpy.linalg.norm()`, which is used in prpy by `ik_ranking.py`.  My system uses an older version of Numpy, and I'd like it to be supported.  This PR does not change the code itself, but instead defines a custom function only when necessary which handles the axis case using the supported `numpy.apply_along_axis()` function.