### PR TITLE
Improvements to VectorFieldPlanner

### DIFF
--- a/src/prpy/planning/exceptions.py
+++ b/src/prpy/planning/exceptions.py
@@ -37,6 +37,35 @@ class CollisionPlanningError(PlanningError):
             return '<unknown>'
 
 
+class JointLimitError(PlanningError):
+    def __init__(self, robot, dof_index, dof_value, dof_limit, description):
+        self.robot = robot
+        self.dof_index = dof_index
+        self.dof_value = dof_value
+        self.dof_limit = dof_limit
+
+        joint = robot.GetJointFromDOFIndex(dof_index)
+        if dof_value < dof_limit:
+            direction = 'lower'
+            comparison = '<'
+        else:
+            direction = 'upper'
+            comparison = '>'
+
+        super(JointLimitError, self).__init__(
+            'Robot "{robot_name:s}" joint "{joint_name:s} axis {joint_axis:d}'
+            ' violates {direction:s} {description:s} limit:'
+            ' {dof_value:.5f} {comparison:s} {dof_limit:.5f}'.format(
+                robot_name=robot.GetName(),
+                joint_name=joint.GetName(),
+                joint_axis=dof_index - joint.GetDOFIndex(),
+                dof_value=dof_value,
+                dof_limit=dof_limit,
+                comparison=comparison,
+                direction=direction,
+                description=description))
+
+
 class SelfCollisionPlanningError(CollisionPlanningError):
     pass
 

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -310,7 +310,9 @@ class VectorFieldPlanner(BasePlanner):
                 if path.GetNumWaypoints() == 1:
                     checks = [(t, q)]
                 else:
-                    # TODO: This should start at t_check.
+                    # TODO: This should start at t_check. Unfortunately, a bug
+                    # in GetCollisionCheckPts causes this to enter an infinite
+                    # loop.
                     checks = GetCollisionCheckPts(robot, path,
                         include_start=False) #start_time=nonlocals['t_check'])
 
@@ -327,13 +329,10 @@ class VectorFieldPlanner(BasePlanner):
                 return -1 # Stop.
 
         # Integrate the vector field to get a configuration space path.
+        # TODO: Tune the integrator parameters.
         integrator = scipy.integrate.ode(f=fn_wrapper)
-        integrator.set_integrator(
-            name='dopri5',
-            first_step=0.1,
-            atol=1e-3,
-            rtol=1e-3,
-        )
+        integrator.set_integrator(name='dopri5',
+            first_step=0.1, atol=1e-3, rtol=1e-3)
         integrator.set_solout(fn_callback)
         integrator.set_initial_value(y=robot.GetActiveDOFValues(), t=0.)
         integrator.integrate(t=integration_timelimit)

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -84,7 +84,7 @@ class VectorFieldPlanner(BasePlanner):
             twist = util.GeodesicTwist(manip.GetEndEffectorTransform(),
                                             goal_pose)
             dqout, tout = util.ComputeJointVelocityFromTwist(
-                                robot, twist)
+                robot, twist, joint_velocity_limits=numpy.PINF)
 
             # Go as fast as possible
             vlimits = robot.GetDOFVelocityLimits(robot.GetActiveDOFIndices())
@@ -147,8 +147,10 @@ class VectorFieldPlanner(BasePlanner):
             twist = util.GeodesicTwist(manip.GetEndEffectorTransform(),
                                             Tstart)
             twist[0:3] = direction
-            dqout, tout = util.ComputeJointVelocityFromTwist(
-                    robot, twist)
+
+            dqout, _ = util.ComputeJointVelocityFromTwist(
+                robot, twist, joint_velocity_limits=numpy.PINF)
+
             return dqout
 
         def TerminateMove():
@@ -174,12 +176,12 @@ class VectorFieldPlanner(BasePlanner):
             if max_distance is None:
                 if distance_moved > distance:
                     return Status.CACHE_AND_TERMINATE
-                else:
-                    return Status.CONTINUE
             elif distance_moved > max_distance:
                 return Status.TERMINATE
             elif distance_moved >= distance:
                 return Status.CACHE_AND_CONTINUE
+
+            return Status.CONTINUE
 
         return self.FollowVectorField(robot, vf_straightline, TerminateMove,
                                       timelimit, **kw_args)
@@ -292,7 +294,7 @@ class VectorFieldPlanner(BasePlanner):
                 # Check the termination condition.
                 waypoint_index = path.GetNumWaypoints() - 1
                 status = fn_terminate()
-                print status
+                #print 'status =', status
 
                 if status in [Status.CACHE_AND_CONTINUE,
                               Status.CACHE_AND_TERMINATE]:

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -729,7 +729,17 @@ def IsTimedTrajectory(trajectory):
     cspec = trajectory.GetConfigurationSpecification()
     return cspec.ExtractDeltaTime(trajectory.GetWaypoint(0)) is not None
 
+
 def ComputeUnitTiming(robot, traj, env=None):
+    """
+    Compute the unit velocity timing of a path or trajectory.
+
+    @param robot: robot whose DOFs should be considered
+    @param traj: path or trajectory
+    @param env: environment to create the output trajectory in; defaults to the
+                same environment as the input trajectory
+    @returns: trajectory with unit velocity timing
+    """
     from openravepy import RaveCreateTrajectory
 
     if env is None:
@@ -741,8 +751,6 @@ def ComputeUnitTiming(robot, traj, env=None):
 
     new_traj = RaveCreateTrajectory(env, '')
     new_traj.Init(cspec)
-
-    dof_values_prev = None
 
     for i in range(traj.GetNumWaypoints()):
         waypoint = traj.GetWaypoint(i, cspec)
@@ -764,7 +772,7 @@ def ComputeUnitTiming(robot, traj, env=None):
 def GetCollisionCheckPts(robot, traj, include_start=True, start_time=0.,
                          first_step=None, epsilon=1e-6):
     """
-    Generates a list of (time, configuration) pairs to collision check.
+    Generate a list of (time, configuration) pairs to collision check.
 
     If every generated configuration is collision free, then the trajectory is
     guaranteed to be collision free up to DOF resolution. This function only
@@ -775,6 +783,8 @@ def GetCollisionCheckPts(robot, traj, include_start=True, start_time=0.,
     @param trajectory: timed trajectory
     @returns generator of (time, configuration) pairs 
     """
+
+    # TODO: This enters an infinite loop if start_time is non-zero.
 
     if not IsTimedTrajectory(traj):
         raise ValueError(

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -788,10 +788,12 @@ def GetCollisionCheckPts(robot, traj, include_start=True, start_time=0.,
     q_resolutions = robot.GetDOFResolutions()[dof_indices]
     duration = traj.GetDuration()
 
-    if not (0. <= start_time < duration):
+    if not (0. <= start_time < duration + epsilon):
         raise ValueError(
             'Start time {:.6f} is out of range [0, {:.6f}].'.format(
                 start_time, duration))
+
+    start_time = min(start_time, duration)
 
     if first_step is None:
         first_step = duration - start_time
@@ -806,7 +808,7 @@ def GetCollisionCheckPts(robot, traj, include_start=True, start_time=0.,
     t_prev = start_time
     q_prev = cspec.ExtractJointValues(
         traj.GetWaypoint(t_prev), robot, dof_indices)
-    dt = duration - start_time
+    dt = first_step
 
     # Always collision check the first point.
     if include_start:


### PR DESCRIPTION
This pull request makes several major improvements to `VectorFieldPlanner` to address #99:

- Decouple the integration step size from the collision and constraint checking resolution.
- Use a numerical integrator (from `scipy.integrate`) instead of fixed-size Euler integration.
- Ignore velocity constraints when defining the vector field.
- All checks are still done during the integration; not as a post-processing step.

It also adds some generally-useful functionality:

- `CACHE_AND_TERMINATE` flag for `TERMINATE`ing while still `CACHE`ing the current configuration
- `ComputeUnitTiming` computes the arclength parameterization of a path or trajectory.
- `GetCollisionCheckPts` generates a sequence of `(t, q)` pairs that are within DOF resolution using the same bisection method as `GreedyIK`
- `ComputeJointVelocityFromTwist` can optionally ignore the robot's velocity limits; e.g. to compute an answer up to scale

**There is one blocking issue:** I can't figure out how to handle numerical precision in `GetCollisionCheckPts` when starting partway through a trajectory. I don't see why this is any different than starting at zero, but it causes the bisection test to get stuck in an infinite loop. I'd appreciate another set of eyes to figure out what I"m doing wrong.

This includes some major changes and has some nasty edge cases. I'd really like @jeking04, @psigen, and @siddhss5 to look at this before I merge it.