### PR TITLE
Added separate exception for trajectory precondition violations.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -205,8 +205,8 @@ class Robot(openravepy.Robot):
            curve through the waypoints (not implemented). If this curve is
            not collision free, then we fall back on...
         4. By default, we run a smoother that jointly times and smooths the
-           path via self.smoother. This algorithm can change the geometric path to
-           optimize runtime.
+           path via self.smoother. This algorithm can change the geometric path
+           to optimize runtime.
 
         The behavior in (2) and (3) can be forced by passing constrained=True
         or smooth=True. By default, the case is inferred by the tag(s) attached
@@ -411,8 +411,8 @@ class Robot(openravepy.Robot):
         else:
             raise ValueError('Received unexpected value "{:s}" for defer.'.format(str(defer)))
 
-
-    def ExecuteTrajectory(self, traj, defer=False, timeout=None, period=0.01, **kwargs):
+    def ExecuteTrajectory(self, traj, defer=False, timeout=None, period=0.01,
+                          **kwargs):
         """ Executes a time trajectory on the robot.
 
         This function directly executes a timed OpenRAVE trajectory on the
@@ -450,7 +450,7 @@ class Robot(openravepy.Robot):
         # Check that the current configuration of the robot matches the
         # initial configuration specified by the trajectory.
         if not util.IsAtTrajectoryStart(self, traj):
-            raise exceptions.TrajectoryAborted(
+            raise exceptions.TrajectoryNotExecutable(
                 'Trajectory started from different configuration than robot.')
 
         # If there was only one waypoint, at this point we are done!

--- a/src/prpy/exceptions.py
+++ b/src/prpy/exceptions.py
@@ -4,7 +4,13 @@ class PrPyException(Exception):
     """
 
 
-class TrajectoryNotExecutable(PrPyException):
+class TrajectoryException(PrPyException):
+    """
+    Trajectory failed to execute.
+    """
+
+
+class TrajectoryNotExecutable(TrajectoryException):
     """
     Trajectory could not begin execution.
 
@@ -17,13 +23,13 @@ class TrajectoryNotExecutable(PrPyException):
     """
 
 
-class TrajectoryAborted(PrPyException):
+class TrajectoryAborted(TrajectoryException):
     """
     Trajectory was aborted.
     """
 
 
-class TrajectoryStalled(PrPyException):
+class TrajectoryStalled(TrajectoryException):
     """
     Trajectory stalled.
     """

--- a/src/prpy/exceptions.py
+++ b/src/prpy/exceptions.py
@@ -3,25 +3,43 @@ class PrPyException(Exception):
     Generic PrPy exception.
     """
 
+
+class TrajectoryNotExecutable(PrPyException):
+    """
+    Trajectory could not begin execution.
+
+    This exception typically indicates that some precondition of trajectory
+    execution was violated, such as the robot starting at a different
+    configuration, the trajectory not being in the correct format.
+
+    This exception indicates that the trajectory was not even attempted due to
+    one of these conditions.
+    """
+
+
 class TrajectoryAborted(PrPyException):
     """
     Trajectory was aborted.
     """
+
 
 class TrajectoryStalled(PrPyException):
     """
     Trajectory stalled.
     """
 
+
 class SynchronizationException(PrPyException):
     """
     Controller synchronization failed.
     """
 
+
 class SerializationException(PrPyException):
     """
     Serialization failed.
     """
+
 
 class UnsupportedTypeSerializationException(SerializationException):
     """
@@ -34,6 +52,7 @@ class UnsupportedTypeSerializationException(SerializationException):
         super(UnsupportedTypeSerializationException, self).__init__(
             'Serializing type "{:s}.{:s}" is not supported.'.format(
                 self.type.__module__, self.type.__name__))
+
 
 class UnsupportedTypeDeserializationException(SerializationException):
     """


### PR DESCRIPTION
This creates a new `prpy.exception` which handles the specific case where a trajectory cannot start execution due to a violation of a required precondition for execution, such as the robot start location.