### PR TITLE
Check attribute name before doing hasattr().

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -45,6 +45,7 @@ class Robot(openravepy.Robot):
     def __init__(self, robot_name=None):
         self.actions = None
         self.planner = None
+        self.detector = None
         self.robot_name = robot_name
 
         try:

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -98,7 +98,9 @@ class Robot(openravepy.Robot):
         # __methods__ bypass __getattribute__.
         self = bind.InstanceDeduplicator.get_canonical(self)
 
-        if (hasattr(self, 'planner') and self.planner is not None
+        if (name != 'planner'
+            and hasattr(self, 'planner')
+            and self.planner is not None
             and self.planner.has_planning_method(name)):
 
             delegate_method = getattr(self.planner, name)
@@ -107,7 +109,9 @@ class Robot(openravepy.Robot):
                 return self._PlanWrapper(delegate_method, args, kw_args)
 
             return wrapper_method
-        elif (hasattr(self, 'actions') and self.actions is not None
+        elif (name != 'actions'
+              and hasattr(self, 'actions')
+              and self.actions is not None
               and self.actions.has_action(name)):
 
             delegate_method = self.actions.get_action(name)
@@ -115,7 +119,9 @@ class Robot(openravepy.Robot):
             def wrapper_method(*args, **kw_args):
                 return delegate_method(self, *args, **kw_args)
             return wrapper_method
-        elif (hasattr(self, 'detector') and self.detector is not None
+        elif (name != 'detector'
+              and hasattr(self, 'detector')
+              and self.detector is not None
               and self.detector.has_perception_method(name)):
             
             delegate_method = getattr(self.detector, name)


### PR DESCRIPTION
This addresses https://github.com/personalrobotics/prpy/issues/207 by first checking that the attribute that is being accessed is not named the same as the attribute that is being used to lookup other methods.