### PR TITLE
Missing Import

### DIFF
--- a/src/prpy/base/wam.py
+++ b/src/prpy/base/wam.py
@@ -28,6 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import math
 import logging
 import numpy
 import openravepy


### PR DESCRIPTION
I called the head command and ServoTo required the math module, which was not imported. Therefore I added import. 