### PR TITLE
Make `Cloned()` handle `None`.

### DIFF
--- a/src/prpy/clone.py
+++ b/src/prpy/clone.py
@@ -186,6 +186,13 @@ def Cloned(*instances, **kwargs):
     clone_instances = list()
 
     for instance in instances:
+        # Check if an instance is `NoneType`.
+        # If it is, it remains NoneType in the cloned environment.
+        if instance is None:
+            clone_instances.append(None)
+            continue
+        
+        # Clone each instance based on its type.
         if isinstance(instance, openravepy.Robot):
             clone_instance = clone_env.GetRobot(instance.GetName())
         elif isinstance(instance, openravepy.KinBody):


### PR DESCRIPTION
Currently, `Cloned(None)` will throw the exception that "`None` is not in the cloned environment".  This is a bit annoying in cases where you to clone an optional object reference, such as a variable that is either a KinBody or `None`.

This change adds logic to make `Cloned(None) = None`.