### PR TITLE
Bugfix/ada trajdescription error

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -412,8 +412,11 @@ class Robot(openravepy.Robot):
 
             with Timer() as timer:
                 exec_traj = self.ExecuteTrajectory(traj, defer=False, **kwargs)
-            SetTrajectoryTags(exec_traj, {Tags.EXECUTION_TIME: timer.get_duration()}, append=True)
-            return exec_traj
+            print exec_traj.__class__
+            print traj.__class__
+            #SetTrajectoryTags(exec_traj, {Tags.EXECUTION_TIME: timer.get_duration()}, append=True)
+            #return exec_traj
+            return traj
 
         if defer is True:
             from trollius.executor import get_default_executor

--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -412,8 +412,6 @@ class Robot(openravepy.Robot):
 
             with Timer() as timer:
                 exec_traj = self.ExecuteTrajectory(traj, defer=False, **kwargs)
-            print exec_traj.__class__
-            print traj.__class__
             #SetTrajectoryTags(exec_traj, {Tags.EXECUTION_TIME: timer.get_duration()}, append=True)
             #return exec_traj
             return traj


### PR DESCRIPTION
When executing trajectories for ada, the execution occurs, but the following error is thrown:
"AttributeError: 'JointTrajectory' object has no attribute 'GetDescription'"

Seems to be a problem with exec_traj (line 414) not having a description. this error is thrown on the following line in util.py:
294     description = traj.GetDescription()
Returning the other trajectory traj doesn't produce the same error

Note that traj is of class 'openravepy._openravepy_.openravepy_int.Trajectory', while exec_traj is class 'trajectory_msgs.msg._JointTrajectory.JointTrajectory'