### PR TITLE
Adds a timing check to `JointStatesFromTraj()`.

### DIFF
--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1382,14 +1382,16 @@ def JointStatesFromTraj(robot, traj, times, derivatives=[0, 1, 2]):
     @param traj An OpenRAVE trajectory
     @param times List of times in seconds
     @param derivatives list of desired derivatives defaults to [0, 1, 2]
-    @return pva_list List of list of derivatives at specified times.
-                     Inserts 'None' for unavailable or undesired fields
-                     The i-th element is the derivatives[i]-th derivative
-                     of position of size |times| x |derivatives|
-
+    @return List of list of derivatives at specified times.
+            Inserts 'None' for unavailable or undesired fields
+            The i-th element is the derivatives[i]-th derivative
+            of position of size |times| x |derivatives|
     """
-    duration = traj.GetDuration()
+    if not IsTimedTrajectory(traj):
+        raise ValueError("Joint states can only be interpolated"
+                         " on a timed trajectory.")
 
+    duration = traj.GetDuration()
     times = numpy.array(times)
     if any(times > duration):
         raise ValueError('Input times {0:} exceed duration {1:.2f}'
@@ -1418,10 +1420,10 @@ def JointStateFromTraj(robot, traj, time, derivatives=[0, 1, 2]):
     @param traj An OpenRAVE trajectory
     @param time time in seconds
     @param derivatives list of desired derivatives defaults to [0, 1, 2]
-    @return pva_list List of list of derivatives at specified times.
-                     Inserts 'None' for unavailable or undesired fields
-                     The i-th element is the derivatives[i]-th derivative
-                     of position of size |times| x |derivatives|
+    @return List of list of derivatives at specified times.
+            Inserts 'None' for unavailable or undesired fields
+            The i-th element is the derivatives[i]-th derivative
+            of position of size |times| x |derivatives|
     """
     return JointStatesFromTraj(robot, traj, (time,), derivatives)[0]
 


### PR DESCRIPTION
Previously, calling `JointStateFromTraj()` on an untimed
trajectory with time = 0.0 would result in an `openrave_exception`.
Now, it will raise a `ValueError` reporting that untimed
trajectories cannot be used in the function.