### PR TITLE
(moved) Add PlanWorkspacePath() method to VectorFieldPlanner

### DIFF
--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -225,7 +225,8 @@ class VectorFieldPlanner(BasePlanner):
     @PlanningMethod
     def FollowVectorField(self, robot, fn_vectorfield, fn_terminate,
                           integration_timelimit=10.,
-                          timelimit=5.0, dt_multiplier=1.01, **kw_args):
+                          timelimit=5.0,
+                          **kw_args):
         """
         Follow a joint space vectorfield to termination.
 
@@ -233,10 +234,6 @@ class VectorFieldPlanner(BasePlanner):
         @param fn_vectorfield a vectorfield of joint velocities
         @param fn_terminate custom termination condition
         @param timelimit time limit before giving up
-        @param dt_multiplier multiplier of the minimum resolution at which
-               the vector field will be followed. Defaults to 1.0.
-               Any larger value means the vectorfield will be re-evaluated
-               floor(dt_multiplier) steps
         @param kw_args keyword arguments to be passed to fn_vectorfield
         @return traj
         """

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -112,8 +112,11 @@ class VectorFieldPlanner(BasePlanner):
                 return Status.TERMINATE
             return Status.CONTINUE
 
+        integration_timelimit = 10.0
         traj = self.FollowVectorField(robot, vf_geodesic, CloseEnough,
-                                      timelimit)
+                                      integration_timelimit,
+                                      timelimit,
+                                      **kw_args)
 
         # Flag this trajectory as unconstrained. This overwrites the
         # constrained flag set by FollowVectorField.
@@ -197,8 +200,11 @@ class VectorFieldPlanner(BasePlanner):
 
             return Status.CONTINUE
 
+        integration_timelimit = 10.0
         return self.FollowVectorField(robot, vf_straightline, TerminateMove,
-                                      timelimit, **kw_args)
+                                      integration_timelimit,
+                                      timelimit, 
+                                      **kw_args)
 
     @PlanningMethod
     def FollowVectorField(self, robot, fn_vectorfield, fn_terminate,

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -233,6 +233,8 @@ class VectorFieldPlanner(BasePlanner):
         @param robot
         @param fn_vectorfield a vectorfield of joint velocities
         @param fn_terminate custom termination condition
+        @param integration_timelimit The initial time step to be taken
+                                     by the integrator.
         @param timelimit time limit before giving up
         @param kw_args keyword arguments to be passed to fn_vectorfield
         @return traj


### PR DESCRIPTION
This PR is to add a PlanWorkspacePath() method to VectorFieldPlanner.

Issue #264 

.

Questions about VectorFieldPlanner in general:
 - If you call PlanToEndEffectorOffset() for some distance, the planner never reaches that distance. Can we fix this?
 - Should we rename the "max_distance" argument?  it seems confusing to me.

Questions about this PR:  
 - Potentially PlanToEndEffectorOffset() could be refactored to call PlanWorkspacePath, however I think PlanToEndEffectorOffset() has a more efficient implementation.
 - Do all the PlanWorkspacePath() methods in each planner need to have the same prototype?
 - To implement PlanWorkspacePath(), I call GetMinDistance... in both of the callbacks, so maybe this is not optimal.
