### PR TITLE
Adding ability to get a list of named configurations

### DIFF
--- a/src/prpy/named_config.py
+++ b/src/prpy/named_config.py
@@ -112,3 +112,9 @@ the following format:
             return self._configs[name]
         else:
             raise KeyError('There is no configuration named %s.' % name)
+    
+    """
+    : return known_configurations: A list of named configurations
+    """
+    def get_configuration_list(self):
+        return self._configs.keys()


### PR DESCRIPTION
This pull request allows you to get a list of known configurations via:
```
named_configs = robot.configurations.get_configuration_list()
```