### PR TITLE
Removed duplicate @PlanningMethod decorators.

### DIFF
--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -154,7 +154,6 @@ class HauserParabolicSmoother(OpenRAVERetimer):
             'time_limit': float(timelimit),
         })
 
-    @PlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kw_args):
         from copy import deepcopy
         if options is None:
@@ -163,6 +162,7 @@ class HauserParabolicSmoother(OpenRAVERetimer):
         new_options['time_limit'] = kw_args.get('timelimit', 3.)
         return super(HauserParabolicSmoother, self).RetimeTrajectory(
             robot, path, options=new_options, **kw_args)
+
 
 class OpenRAVEAffineRetimer(BasePlanner):
     def __init__(self,):

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -112,8 +112,8 @@ class VectorFieldPlanner(BasePlanner):
                 return Status.TERMINATE
             return Status.CONTINUE
 
-        traj = self.FollowVectorField(robot, vf_geodesic, CloseEnough,
-                                      timelimit)
+        traj = self._FollowVectorField(robot, vf_geodesic, CloseEnough,
+                                       timelimit)
 
         # Flag this trajectory as unconstrained. This overwrites the
         # constrained flag set by FollowVectorField.
@@ -197,8 +197,8 @@ class VectorFieldPlanner(BasePlanner):
 
             return Status.CONTINUE
 
-        return self.FollowVectorField(robot, vf_straightline, TerminateMove,
-                                      timelimit, **kw_args)
+        return self._FollowVectorField(robot, vf_straightline, TerminateMove,
+                                       timelimit, **kw_args)
 
     @PlanningMethod
     def FollowVectorField(self, robot, fn_vectorfield, fn_terminate,
@@ -206,6 +206,32 @@ class VectorFieldPlanner(BasePlanner):
                           timelimit=5.0, dt_multiplier=1.01, **kw_args):
         """
         Follow a joint space vectorfield to termination.
+
+        @param robot
+        @param fn_vectorfield a vectorfield of joint velocities
+        @param fn_terminate custom termination condition
+        @param timelimit time limit before giving up
+        @param dt_multiplier multiplier of the minimum resolution at which
+               the vector field will be followed. Defaults to 1.0.
+               Any larger value means the vectorfield will be re-evaluated
+               floor(dt_multiplier) steps
+        @param kw_args keyword arguments to be passed to fn_vectorfield
+        @return traj
+        """
+        return self._FollowVectorField(robot, fn_vectorfield, fn_terminate,
+                                       integration_timelimit=10.,
+                                       timelimit=5.0, dt_multiplier=1.01,
+                                       **kw_args)
+
+    def _FollowVectorField(self, robot, fn_vectorfield, fn_terminate,
+                           integration_timelimit=10.,
+                           timelimit=5.0, dt_multiplier=1.01, **kw_args):
+        """
+        Follow a joint space vectorfield to termination.
+
+        This is the _internal_ version of this call, meant to be called
+        from within a @PlanningMethod.  Consider using the un-prefixed
+        version of the call for more general-purpose use.
 
         @param robot
         @param fn_vectorfield a vectorfield of joint velocities

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -80,7 +80,7 @@ class GreedyIKPlanner(BasePlanner):
                 maxaccelerations=0.1*numpy.ones(7)
             )
 
-        return self.PlanWorkspacePath(robot, traj, timelimit)
+        return self._PlanWorkspacePath(robot, traj, timelimit)
 
     @PlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance,
@@ -138,8 +138,8 @@ class GreedyIKPlanner(BasePlanner):
                 maxaccelerations=0.1*numpy.ones(7)
             )
 
-        return self.PlanWorkspacePath(robot, traj,
-                                      timelimit, min_waypoint_index=1)
+        return self._PlanWorkspacePath(robot, traj,
+                                       timelimit, min_waypoint_index=1)
 
     @PlanningMethod
     def PlanWorkspacePath(self, robot, traj, timelimit=5.0,
@@ -147,6 +147,27 @@ class GreedyIKPlanner(BasePlanner):
         """
         Plan a configuration space path given a workspace path.
         All timing information is ignored.
+
+        @param robot
+        @param traj workspace trajectory
+                    represented as OpenRAVE AffineTrajectory
+        @param min_waypoint_index minimum waypoint index to reach
+        @param timelimit timeout in seconds
+        @return qtraj configuration space path
+        """
+        return _PlanWorkspacePath(robot, traj, timelimit=5.0,
+                                  min_waypoint_index=None, **kw_args)
+
+    def _PlanWorkspacePath(self, robot, traj, timelimit=5.0,
+                           min_waypoint_index=None, **kw_args):
+        """
+        Plan a configuration space path given a workspace path.
+        All timing information is ignored.
+
+        This is the _internal_ version of this call, meant to be called
+        from within a @PlanningMethod.  Consider using the un-prefixed
+        version of the call for more general-purpose use.
+
         @param robot
         @param traj workspace trajectory
                     represented as OpenRAVE AffineTrajectory


### PR DESCRIPTION
This commit removes several instances of nested @PlanningMethod
decorators on several of our planners.  It refactors some methods
into internal calls that are wrapped by a new @PlanningMethod instead
so they can be called from multiple @PlanningMethods without duplication.