### PR TITLE
Remove HauserParabolicSmoother as default smoother.

### DIFF
--- a/src/prpy/base/robot.py
+++ b/src/prpy/base/robot.py
@@ -34,7 +34,7 @@ from ..clone import Clone, Cloned
 from ..tsr.tsrlibrary import TSRLibrary
 from ..planning.base import Sequence, Tags
 from ..planning.ompl import OMPLSimplifier
-from ..planning.retimer import HauserParabolicSmoother, OpenRAVEAffineRetimer, ParabolicRetimer
+from ..planning.retimer import OpenRAVEAffineRetimer, ParabolicRetimer
 from ..planning.mac_smoother import MacSmoother
 from ..util import SetTrajectoryTags
 
@@ -71,10 +71,7 @@ class Robot(openravepy.Robot):
         # (joint simplificaiton and retiming).
         self.simplifier = None
         self.retimer = ParabolicRetimer()
-        self.smoother = Sequence(
-            HauserParabolicSmoother(),
-            self.retimer
-        )
+        self.smoother = self.retimer
         self.affine_retimer = OpenRAVEAffineRetimer()
 
     def __dir__(self):


### PR DESCRIPTION
This removes HauserParabolicSmoother as a default smoother inside `prpy.base.robot`. 

Having `HauserParabolicSmoother` hard-coded in this `__init__()` means that _any_ `prpy` robot depends on the external package `or_parabolicsmoother`, even if they do not use it at all in their subclass implementation.

Since we can easily override this default in subclassed (and almost always do to customize the retiming settings anyway), there is no reason to force this dependency.