### PR TITLE
Added separate LockedPlanningMethod and ClonedPlanningMethod calls.

### DIFF
--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -6,7 +6,7 @@
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions are met:
-# 
+#
 # - Redistributions of source code must retain the above copyright notice, this
 #   list of conditions and the following disclaimer.
 # - Redistributions in binary form must reproduce the above copyright notice,
@@ -32,7 +32,7 @@ import numpy
 import openravepy
 from ..util import SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
-                  PlanningMethod, Tags)
+                  ClonedPlanningMethod, Tags)
 import prpy.kin
 import prpy.tsr
 
@@ -48,7 +48,7 @@ class CBiRRTPlanner(BasePlanner):
     def __str__(self):
         return 'CBiRRT'
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfigurations(self, robot, goals, **kw_args):
         """
         Plan to multiple goal configurations with CBiRRT. This adds each goal
@@ -61,7 +61,7 @@ class CBiRRTPlanner(BasePlanner):
         kw_args.setdefault('smoothingitrs', 0)
         return self.Plan(robot, jointgoals=goals, **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Plan to a single goal configuration with CBiRRT.
@@ -72,7 +72,7 @@ class CBiRRTPlanner(BasePlanner):
         kw_args.setdefault('smoothingitrs', 0)
         return self.Plan(robot, jointgoals=[goal], **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorPose(self, robot, goal_pose, **kw_args):
         """
         Plan to a desired end-effector pose.
@@ -90,7 +90,7 @@ class CBiRRTPlanner(BasePlanner):
 
         return self.Plan(robot, tsr_chains=[tsr_chain], **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance,
                                 smoothingitrs=100, **kw_args):
         """
@@ -153,7 +153,7 @@ class CBiRRTPlanner(BasePlanner):
             **kw_args
         )
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsr_chains, smoothingitrs=100, **kw_args):
         """
         Plan to a goal specified as a list of TSR chains. CBiRRT supports an

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -32,10 +32,9 @@ import collections
 import logging
 import numpy
 import openravepy
-from .. import tsr
 from ..util import SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
-                  PlanningMethod, Tags)
+                  ClonedPlanningMethod, Tags)
 import prpy.tsr
 
 logger = logging.getLogger(__name__)
@@ -192,7 +191,7 @@ class CHOMPPlanner(BasePlanner):
         logger.warning('ComputeDistanceField is deprecated. Distance fields are'
                        ' now implicity created by DistanceFieldManager.')
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def OptimizeTrajectory(self, robot, traj, lambda_=100.0, n_iter=50,
                            **kw_args):
         self.distance_fields.sync(robot)
@@ -215,7 +214,7 @@ class CHOMPPlanner(BasePlanner):
         SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
         return traj
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, lambda_=100.0, n_iter=15,
                             **kw_args):
         """
@@ -237,7 +236,7 @@ class CHOMPPlanner(BasePlanner):
         SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
         return traj
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorPose(self, robot, goal_pose, lambda_=100.0,
                               n_iter=100, goal_tolerance=0.01, **kw_args):
         """
@@ -293,7 +292,7 @@ class CHOMPPlanner(BasePlanner):
 
     # JK - Disabling. This is not working reliably.
     '''
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, lambda_=100.0, n_iter=100,
                   goal_tolerance=0.01, **kw_args):
         """

--- a/src/prpy/planning/ik.py
+++ b/src/prpy/planning/ik.py
@@ -33,7 +33,7 @@ import openravepy
 from .. import ik_ranking
 from base import (BasePlanner,
                   PlanningError,
-                  PlanningMethod)
+                  ClonedPlanningMethod)
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class IKPlanner(BasePlanner):
     def __str__(self):
         return 'IKPlanner'
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToIK(self, robot, goal_pose, ranker=ik_ranking.JointLimitAvoidance,
                  num_attempts=1, **kw_args):
         from openravepy import (IkFilterOptions,

--- a/src/prpy/planning/mac_smoother.py
+++ b/src/prpy/planning/mac_smoother.py
@@ -30,7 +30,7 @@
 
 from ..util import (CopyTrajectory, SimplifyTrajectory, SetTrajectoryTags,
                     IsTimedTrajectory)
-from base import (BasePlanner, PlanningError, PlanningMethod,
+from base import (BasePlanner, PlanningError, ClonedPlanningMethod,
                   UnsupportedPlanningError, Tags)
 from openravepy import (Planner, PlannerStatus, RaveCreatePlanner,
                         openrave_exception)
@@ -54,7 +54,7 @@ class MacSmoother(BasePlanner):
                 ' installed and in your OPENRAVE_PLUGIN path?'
             )
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def RetimeTrajectory(self, robot, path):
         # Copy the input trajectory into the planning environment. This is
         # necessary for two reasons: (1) the input trajectory may be in another
@@ -72,8 +72,8 @@ class MacSmoother(BasePlanner):
             params = Planner.PlannerParameters()
             self.blender.InitPlan(robot, params)
             status = self.blender.PlanPath(output_traj)
-            if status not in [ PlannerStatus.HasSolution,
-                               PlannerStatus.InterruptedWithSolution ]:
+            if status not in [PlannerStatus.HasSolution,
+                              PlannerStatus.InterruptedWithSolution]:
                 raise PlanningError('Blending trajectory failed.')
         except openrave_exception as e:
             raise PlanningError('Blending trajectory failed: ' + str(e))
@@ -84,12 +84,11 @@ class MacSmoother(BasePlanner):
             params = Planner.PlannerParameters()
             self.retimer.InitPlan(robot, params)
             status = self.retimer.PlanPath(output_traj)
-            if status not in [ PlannerStatus.HasSolution,
-                               PlannerStatus.InterruptedWithSolution ]:
+            if status not in [PlannerStatus.HasSolution,
+                              PlannerStatus.InterruptedWithSolution]:
                 raise PlanningError('Timing trajectory failed.')
         except openrave_exception as e:
             raise PlanningError('Timing trajectory failed: ' + str(e))
 
         SetTrajectoryTags(output_traj, {Tags.SMOOTH: True}, append=True)
         return output_traj
-

--- a/src/prpy/planning/mk.py
+++ b/src/prpy/planning/mk.py
@@ -30,8 +30,8 @@
 
 import logging, numpy, openravepy, time
 from ..util import SetTrajectoryTags
-from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
-                  PlanningMethod, Tags)
+from base import (BasePlanner, PlanningError,
+                  ClonedPlanningMethod, Tags)
 
 logger = logging.getLogger(__name__)
 
@@ -100,7 +100,7 @@ class MKPlanner(BasePlanner):
 
         return numpy.dot(jacobian_pinv, pose_error) + numpy.dot(nullspace_projector, nullspace_goal)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance, max_distance=None,
                                 nullspace=JointLimitAvoidance, timelimit=5.0, step_size=0.001,
                                 position_tolerance=0.01, angular_tolerance=0.15, **kw_args):

--- a/src/prpy/planning/named.py
+++ b/src/prpy/planning/named.py
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import logging, numpy, openravepy
-from base import BasePlanner, PlanningError, UnsupportedPlanningError, PlanningMethod
+from base import BasePlanner, PlanningError, ClonedPlanningMethod
 
 class NamedPlanner(BasePlanner):
     def __init__(self, delegate_planner=None):
@@ -41,7 +41,7 @@ class NamedPlanner(BasePlanner):
     def __str__(self):
         return 'NamedPlanner'
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToNamedConfiguration(self, robot, name, **kw_args):
         """ Plan to a named configuration.
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -33,7 +33,7 @@ import numpy
 import openravepy
 from ..util import CopyTrajectory, SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
-                  PlanningMethod, Tags)
+                  ClonedPlanningMethod, Tags)
 from openravepy import PlannerStatus
 from .cbirrt import SerializeTSRChain
 
@@ -58,7 +58,7 @@ class OMPLPlanner(BasePlanner):
     def __str__(self):
         return 'OMPL {0:s}'.format(self.algorithm)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Plan to a desired configuration with OMPL. This will invoke the OMPL
@@ -69,7 +69,7 @@ class OMPLPlanner(BasePlanner):
         """
         return self._Plan(robot, goal=goal, **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, **kw_args):
         """
         Plan using the given set of TSR chains with OMPL.
@@ -159,7 +159,7 @@ class RRTConnect(OMPLPlanner):
                          ompl_range)
         return ompl_args
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, ompl_args=None, **kw_args):
         """
         Plan to a desired configuration with OMPL. This will invoke the OMPL
@@ -171,7 +171,7 @@ class RRTConnect(OMPLPlanner):
         ompl_args = self._SetPlannerRange(robot, ompl_args=ompl_args)
         return self._Plan(robot, goal=goal, ompl_args=ompl_args, **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, ompl_args=None, **kw_args):
         """
         Plan using the given TSR chains with OMPL.
@@ -198,7 +198,7 @@ class OMPLSimplifier(BasePlanner):
     def __str__(self):
         return 'OMPL Simplifier'
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def ShortcutPath(self, robot, path, timeout=1., **kwargs):
         # The planner operates in-place, so we need to copy the input path. We
         # also need to copy the trajectory into the planning environment.

--- a/src/prpy/planning/openrave.py
+++ b/src/prpy/planning/openrave.py
@@ -35,7 +35,7 @@ import openravepy
 from base import (BasePlanner,
                   PlanningError,
                   UnsupportedPlanningError,
-                  PlanningMethod)
+                  ClonedPlanningMethod)
 
 
 class OpenRAVEPlanner(BasePlanner):
@@ -54,7 +54,7 @@ class OpenRAVEPlanner(BasePlanner):
     def __str__(self):
         return 'OpenRAVE {0:s}'.format(self.algorithm)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Plan to a desired configuration with OpenRAVE. This will invoke the
@@ -116,7 +116,7 @@ class BiRRTPlanner(OpenRAVEPlanner):
     def __init__(self):
         OpenRAVEPlanner.__init__(self, algorithm='birrt')
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Plan to a desired configuration with OpenRAVE. This will invoke the
@@ -127,7 +127,7 @@ class BiRRTPlanner(OpenRAVEPlanner):
         """
         return self._Plan(robot, goal, **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfigurations(self, robot, goals, **kw_args):
         """
         Plan to one of many configuration with OpenRAVE's BiRRT planner.

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -33,7 +33,7 @@ import openravepy
 from copy import deepcopy
 from ..util import (CreatePlannerParametersString, CopyTrajectory,
                     SimplifyTrajectory, HasAffineDOFs, IsTimedTrajectory)
-from base import (BasePlanner, PlanningError, PlanningMethod,
+from base import (BasePlanner, PlanningError, ClonedPlanningMethod,
                   UnsupportedPlanningError)
 from openravepy import PlannerStatus, Planner
 
@@ -58,7 +58,7 @@ class OpenRAVERetimer(BasePlanner):
     def __str__(self):
         return self.algorithm
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kw_args):
         from openravepy import CollisionOptions, CollisionOptionsStateSaver
         from copy import deepcopy
@@ -155,7 +155,7 @@ class HauserParabolicSmoother(OpenRAVERetimer):
             'time_limit': float(timelimit),
         })
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kw_args):
         new_options = deepcopy(options) if options else dict()
         if 'timelimit' in kw_args:
@@ -167,7 +167,7 @@ class OpenRAVEAffineRetimer(BasePlanner):
     def __init__(self,):
         super(OpenRAVEAffineRetimer, self).__init__()
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def RetimeTrajectory(self, robot, path, **kw_args):
 
         RetimeTrajectory = openravepy.planningutils.RetimeAffineTrajectory
@@ -212,7 +212,7 @@ class OpenRAVEAffineRetimer(BasePlanner):
 
 
 class OptimizingPlannerSmoother(BasePlanner):
-    
+
     def __init__(self, optimizing_planner, **kwargs):
         super(OptimizingPlannerSmoother, self).__init__()
         self.planner = optimizing_planner
@@ -220,8 +220,8 @@ class OptimizingPlannerSmoother(BasePlanner):
 
     def __str__(self):
         return 'OptimizingPlannerSmoother({})'.format(str(self.planner))
-    
-    @PlanningMethod
+
+    @ClonedPlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kwargs):
         logger.warning(
             'OptimizingPlannerSmoother is very experimental!')
@@ -229,4 +229,3 @@ class OptimizingPlannerSmoother(BasePlanner):
         this_kwargs.update(self.saved_kwargs)
         traj = self.planner.OptimizeTrajectory(robot, path, **this_kwargs)
         return traj
-        

--- a/src/prpy/planning/sbpl.py
+++ b/src/prpy/planning/sbpl.py
@@ -15,7 +15,7 @@
 # - Neither the name of Carnegie Mellon University nor the names of its
 #   contributors may be used to endorse or promote products derived from this
 #   software without specific prior written permission.
-# 
+#
 # THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
 # AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
 # IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
@@ -28,13 +28,13 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-from base import BasePlanner, PlanningError, PlanningMethod, UnsupportedPlanningError
+from base import BasePlanner, PlanningError, ClonedPlanningMethod, UnsupportedPlanningError
 import openravepy
 
 class SBPLPlanner(BasePlanner):
     def __init__(self):
         super(SBPLPlanner, self).__init__()
-        
+
         try:
             self.planner = openravepy.RaveCreatePlanner(self.env, 'SBPL')
         except openravepy.openrave_exception:
@@ -53,7 +53,7 @@ class SBPLPlanner(BasePlanner):
     def SetPlannerParameters(self, params_yaml):
         self.planner_params = params_yaml
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToBasePose(self, robot, goal_pose, timelimit=60.0, return_first=False, **kw_args):
         """
         Plan to a base pose using SBPL

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -33,7 +33,6 @@ from prpy.util import SetTrajectoryTags
 from prpy.planning.base import (
     BasePlanner,
     PlanningError,
-    LockedPlanningMethod,
     ClonedPlanningMethod,
     Tags
 )

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -30,10 +30,13 @@
 import numpy
 import openravepy
 from prpy.util import SetTrajectoryTags
-from prpy.planning.base import BasePlanner
-from prpy.planning.base import PlanningError
-from prpy.planning.base import PlanningMethod
-from prpy.planning.base import Tags
+from prpy.planning.base import (
+    BasePlanner,
+    PlanningError,
+    LockedPlanningMethod,
+    ClonedPlanningMethod,
+    Tags
+)
 
 
 class SnapPlanner(BasePlanner):
@@ -55,7 +58,7 @@ class SnapPlanner(BasePlanner):
     def __str__(self):
         return 'SnapPlanner'
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Attempt to plan a straight line trajectory from the robot's
@@ -66,10 +69,9 @@ class SnapPlanner(BasePlanner):
         @param goal desired configuration
         @return traj
         """
-
         return self._Snap(robot, goal, **kw_args)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorPose(self, robot, goal_pose, **kw_args):
         """
         Attempt to plan a straight line trajectory from the robot's
@@ -99,7 +101,7 @@ class SnapPlanner(BasePlanner):
             ik_param, ikfo.CheckEnvCollisions,
             ikreturn=False, releasegil=True
         )
-        
+
         if ik_solution is None: 
             # FindIKSolutions is slower than FindIKSolution, 
             # so call this only to identify and raise error when
@@ -116,7 +118,7 @@ class SnapPlanner(BasePlanner):
                     raise CollisionPlanningError.FromReport(report) 
                 elif robot.CheckSelfCollision(report=report):
                     raise SelfCollisionPlanningError.FromReport(report)
-            
+
             raise PlanningError('There is no IK solution at the goal pose.')
 
         return self._Snap(robot, ik_solution, **kw_args)

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -32,7 +32,7 @@ import time
 import itertools
 import numpy
 import openravepy
-from base import (BasePlanner, PlanningMethod, PlanningError,
+from base import (BasePlanner, ClonedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
 
 logger = logging.getLogger(__name__)
@@ -51,7 +51,7 @@ class TSRPlanner(BasePlanner):
 
     # TODO: Temporarily disabled based on Pras' feedback.
     """
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToIK(self, robot, goal_pose, **kw_args):
         from ..tsr import TSR, TSRChain
 
@@ -61,7 +61,7 @@ class TSRPlanner(BasePlanner):
         return self.PlanToTSR(robot, [tsr_chain], **kw_args)
     """
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=2.0,
                   num_attempts=3, chunk_size=1, ranker=None,
                   max_deviation=2*numpy.pi, **kw_args):

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -33,11 +33,9 @@
 import logging
 import numpy
 import openravepy
-import time
 from .. import util
-from base import BasePlanner, PlanningError, PlanningMethod, Tags
+from base import BasePlanner, PlanningError, ClonedPlanningMethod, Tags
 from enum import Enum
-import math
 
 logger = logging.getLogger(__name__)
 
@@ -81,12 +79,10 @@ class VectorFieldPlanner(BasePlanner):
     def __str__(self):
         return 'VectorFieldPlanner'
 
-
-
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorPose(self, robot, goal_pose, timelimit=5.0,
                               pose_error_tol=0.01,
-                              integration_interval = 10.0,
+                              integration_interval=10.0,
                               **kw_args):
         """
         Plan to an end effector pose by following a geodesic loss function
@@ -139,12 +135,12 @@ class VectorFieldPlanner(BasePlanner):
         util.SetTrajectoryTags(traj, {Tags.CONSTRAINED: False}, append=True)
         return traj
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance,
                                 max_distance=None, timelimit=5.0,
                                 position_tolerance=0.01,
                                 angular_tolerance=0.15,
-                                integration_interval = 10.0,
+                                integration_interval=10.0,
                                 **kw_args):
         """
         Plan to a desired end-effector offset with move-hand-straight
@@ -183,7 +179,7 @@ class VectorFieldPlanner(BasePlanner):
             Function defining a joint-space vector field.
             """
             twist = util.GeodesicTwist(manip.GetEndEffectorTransform(),
-                                            Tstart)
+                                       Tstart)
             twist[0:3] = direction
 
             dqout, _ = util.ComputeJointVelocityFromTwist(
@@ -232,16 +228,15 @@ class VectorFieldPlanner(BasePlanner):
                                       timelimit, 
                                       **kw_args)
 
-
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanWorkspacePath(self, robot, traj,
                           timelimit=5.0,
                           position_tolerance=0.01,
                           angular_tolerance=0.15,
-                          t_step = 0.001,
+                          t_step=0.001,
                           Kp_ff=None,
                           Kp_e=None,
-                          integration_interval = 10.0,
+                          integration_interval=10.0,
                           **kw_args):
         """
         Plan a configuration space path given a workspace path.
@@ -422,8 +417,7 @@ class VectorFieldPlanner(BasePlanner):
                                       integration_interval,
                                       timelimit, **kw_args)
 
-
-    @PlanningMethod
+    @ClonedPlanningMethod
     def FollowVectorField(self, robot, fn_vectorfield, fn_terminate,
                           integration_time_interval=10.0,
                           timelimit=5.0,
@@ -604,4 +598,3 @@ class VectorFieldPlanner(BasePlanner):
             }, append=True
         )
         return output_path
-

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -34,7 +34,7 @@ import numpy
 import openravepy
 import time
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, PlanningMethod, Tags
+from base import BasePlanner, PlanningError, ClonedPlanningMethod, Tags
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +46,7 @@ class GreedyIKPlanner(BasePlanner):
     def __str__(self):
         return 'GreedyIKPlanner'
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorPose(self, robot, goal_pose, timelimit=5.0,
                               **kw_args):
         """
@@ -82,7 +82,7 @@ class GreedyIKPlanner(BasePlanner):
 
         return self.PlanWorkspacePath(robot, traj, timelimit)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance,
                                 max_distance=None, timelimit=5.0,
                                 **kw_args):
@@ -141,7 +141,7 @@ class GreedyIKPlanner(BasePlanner):
         return self.PlanWorkspacePath(robot, traj,
                                       timelimit, min_waypoint_index=1)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanWorkspacePath(self, robot, traj, timelimit=5.0,
                           min_waypoint_index=None, **kw_args):
         """

--- a/tests/planning/planning_helpers.py
+++ b/tests/planning/planning_helpers.py
@@ -1,5 +1,6 @@
 import numpy
-from prpy.planning.base import BasePlanner, PlanningMethod
+from prpy.planning.base import BasePlanner, ClonedPlanningMethod
+
 
 class BasePlannerTest(object):
     is_setup = False
@@ -17,7 +18,6 @@ class BasePlannerTest(object):
         -2.61799387,  0.66440338,  0.19853743,  2.00944286, -0.08639925,
         -0.69750467,  1.31656153
     ])
-
 
     config_feasible_goal = numpy.array([
         -0.84085883,  1.44573701,  0.20000000,  1.72620231, -0.81124757,
@@ -206,7 +206,7 @@ class SuccessPlanner(MockPlanner):
             self.traj = RaveCreateTrajectory(self.env, template_traj.GetXMLId())
             self.traj.Clone(template_traj, 0)
 
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanTest(self, robot):
 
         def Success_impl(robot):
@@ -224,7 +224,7 @@ class SuccessPlanner(MockPlanner):
 
 
 class FailPlanner(MockPlanner):
-    @PlanningMethod
+    @ClonedPlanningMethod
     def PlanTest(self, robot):
 
         def Failure_impl(robot):


### PR DESCRIPTION
**This should be merged _after_ #278 and #279.**

This separates the `@PlanningMethod` decorator into two decorators:

- `@LockedPlanningMethod` locks the current robot environment and executes the wrapped method.
- `@ClonedPlanningMethod` clones the current robot environment and executes the wrapped method.

This distinction is useful for planning calls that are so fast that they take less time than the cloning operation itself, such as optimistic plans like `SnapPlanner` and fast mathematical solutions such as `KunzCircularBlender`.

This commit refactors all existing planning calls except `SnapPlanner` to use `@ClonedPlanningMethod` and updates the README to explain the distinction.  `@PlanningMethod` is changed to inherit from `@ClonedPlanningMethod` but print a warning if it is used.