### PR TITLE
Added copying of trajectory description to CopyTrajectory.

### DIFF
--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -291,6 +291,7 @@ def CopyTrajectory(traj, env=None):
     copy_traj = openravepy.RaveCreateTrajectory(env or traj.GetEnv(),
                                                 traj.GetXMLId())
     copy_traj.Clone(traj, 0)
+    copy_traj.SetDescription(traj.GetDescription())
     return copy_traj
 
 


### PR DESCRIPTION
This was a bug noticed by @mkoval in #278.

`CopyTrajectory` should also copy the `GetDescription()` string from the source trajectory into the copy that is returned.