### PR TITLE
Fixed bug introduced by clone refactor.

### DIFF
--- a/src/prpy/clone.py
+++ b/src/prpy/clone.py
@@ -108,7 +108,7 @@ class Clone(object):
                                     ' while in collision.'
                                     .format(robot.GetName())
                                 )
-                            cloned_robot = self.clone_env.Cloned(robot)
+                            cloned_robot = Cloned(robot, into=self.clone_env)
                             cloned_robot.RegrabAll()
 
             # Required for InstanceDeduplicator to call CloneBindings for


### PR DESCRIPTION
We reordered the logic for the definition of the `env.Cloned` helper method but did not remove the original reference.