### PR TITLE
issue #292 | issue #293

### DIFF
--- a/src/prpy/perception/apriltags.py
+++ b/src/prpy/perception/apriltags.py
@@ -134,6 +134,7 @@ class ApriltagsModule(PerceptionModule):
         return_obj = None
         for obj in added_bodies:
             if obj.GetName() != object_name:
+                env = robot.GetEnv()
                 env.Remove(obj)
             else:
                 return_obj = obj


### PR DESCRIPTION
issue #292 
DetectObjects() returns duplicate kinbodies in prpy.perception.apriltags.py 

 issue #293 
 env is not defined, in DetectObject() in prpy.perception.apriltags.py