### PR TITLE
Fixed spurious CloneException errors in planning stack.

### DIFF
--- a/src/prpy/clone.py
+++ b/src/prpy/clone.py
@@ -193,7 +193,7 @@ def Cloned(*instances, **kwargs):
         if instance is None:
             clone_instances.append(None)
             continue
-        
+
         # Clone each instance based on its type.
         if isinstance(instance, openravepy.Robot):
             clone_instance = clone_env.GetRobot(instance.GetName())

--- a/src/prpy/planning/exceptions.py
+++ b/src/prpy/planning/exceptions.py
@@ -94,3 +94,31 @@ class TimeoutPlanningError(PlanningError):
             message = 'Exceeded time limit.'
 
         super(TimeoutPlanningError, self).__init__(message)
+
+
+class MetaPlanningError(PlanningError):
+    """
+    A metaplanning error indicates that a planning operation that calls one or
+    more other planners internally failed due to the internal planning calls
+    failing.
+    """
+    def __init__(self, message, errors):
+        PlanningError.__init__(self, message)
+        self.errors = errors
+
+    # TODO: Print the inner exceptions.
+
+
+class ClonedPlanningError(PlanningError):
+    """
+    A cloned planning error indicates that planning failed because a
+    ClonedPlanningMethod was unable to clone the environment successfully.
+
+    This most commonly occurs when a planner attempts to clone while in
+    collision, which can corrupt the environment before the planner would
+    have a chance to detect the collision.
+    """
+    def __init__(self, cloning_error):
+        super(ClonedPlanningError, self).__init__(
+            "Failed to clone: {:s}".format(cloning_error))
+        self.error = cloning_error


### PR DESCRIPTION
Due to OpenRAVE weirdness, we are forced to throw a `CloneException` if a robot is cloned from a self-colliding configuration.  We also clone at the beginning of some of our planning operations.

This means that calling a planning method while a robot is in self-collision can create a `CloneException`, which is generally not expected or handled in code that is calling a planning method.  It is also not clear to calling code that this is actually a failure within a planner, and it breaks `MetaPlanner` logic.

In this PR, `ClonedPlanningMethod`s will catch `CloneException`s and wrap them as `ClonedPlanningError`s instead, which inherit from `PlanningError` and are thus handled correctly throughout the planning stack as a form of planning failure.