### PR TITLE
Features/tracik solver

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -32,6 +32,7 @@
   <run_depend>python-rospkg</run_depend>
   <run_depend>python-yaml</run_depend>
   <run_depend>python-lxml</run_depend>
+  <run_depend>or_trac_ik</run_depend>
   <test_depend>python-nose</test_depend>
   <!-- These optional dependencies cause unit tests can fail if missing. -->
   <test_depend>cbirrt2</test_depend>

--- a/package.xml
+++ b/package.xml
@@ -32,7 +32,6 @@
   <run_depend>python-rospkg</run_depend>
   <run_depend>python-yaml</run_depend>
   <run_depend>python-lxml</run_depend>
-  <run_depend>or_trac_ik</run_depend>
   <test_depend>python-nose</test_depend>
   <!-- These optional dependencies cause unit tests can fail if missing. -->
   <test_depend>cbirrt2</test_depend>

--- a/src/prpy/base/mico.py
+++ b/src/prpy/base/mico.py
@@ -60,7 +60,7 @@ class Mico(Manipulator):
         # Load or_nlopt_ik as the IK solver. Unfortunately, IKFast doesn't work
         # on the Mico.
         if iktype is not None:
-            self.iksolver = openravepy.RaveCreateIkSolver(env, 'NloptIK')
+            self.iksolver = openravepy.RaveCreateIkSolver(env, 'TracIK')
             self.SetIKSolver(self.iksolver)
 
         # Load simulation controllers.


### PR DESCRIPTION
Changed the default ik solver for ada to use trac_ik.

Note that I didn't add a dependency to package.xml - I didn't see the nlopt package there. Additionally, or_trac_ik depends on trac-ik which depends on moveit, so forcing everyone to depend on it means everyone has to install all of moveit. So, not sure if you want that.