### PR TITLE
Changes VanDerCorputSampleGenerator to include goal.

### DIFF
--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1544,7 +1544,7 @@ def VanDerCorputSampleGenerator(start, end, step=2):
         if numpy.all(is_checked):
             return
 
-        idx = numpy.digitize((s,), check_bins)
+        idx = numpy.digitize((s,), check_bins, right=True)
         if is_checked[idx]:
             continue
 

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1510,8 +1510,7 @@ def VanDerCorputSampleGenerator(start, end, step=2):
     Generates a sequence of values from start to end, with specified
     step size, using an approximate binary Van der Corput sequence.
 
-    The end value is also returned if it's more than half the
-    distance from the closest value.
+    The start and end values will always be checked first.
 
     For example, on the interval [0.0, 13.7], the sequence is:
     [0.0, 13.7, 12.0, 6.0, 4.0, 8.0, 2.0, 10.0]
@@ -1522,8 +1521,6 @@ def VanDerCorputSampleGenerator(start, end, step=2):
 
     @returns generator: A sequence of float values.
     """
-    import itertools
-
     # 'start' and 'end' must be positive because
     # itertools.islice() only accepts a positive integer
     if end <= start:
@@ -1532,48 +1529,27 @@ def VanDerCorputSampleGenerator(start, end, step=2):
     if not (step > 0):
         raise ValueError("The 'step' value must be positive.")
 
-    # The duration, rounded to nearest step-size
-    mod_end = int(end - (end % step))
-    steps_to_take = mod_end / float(step)
-    leftover_time = end - float(mod_end)
+    # Construct the points at which checks must occur to cover this range.
+    check_bins = numpy.arange(start, end, step)
+    is_checked = [False] * len(check_bins)
 
-    # Keep a list to make sure we return all the sample values
-    times_sampled = [False for i in range(mod_end + 1)]
+    # Always return the start and end points first.
+    is_checked[0] = True
+    yield start
+    yield end
 
-    vdc = VanDerCorputSequence(start, steps_to_take)
-    vdc_seq = itertools.islice(vdc, steps_to_take + 1)
-    count = 0
-    for s in vdc_seq:
-        # Snap this sample value to the desired step-size
-        idx = int(step * numpy.round(s))
-        if (idx % step) != 0:
-            idx = idx + 1
+    # Return a collision-checking sequence that eventually covers the range.
+    vdc = VanDerCorputSequence(lower=start, upper=end, include_endpoints=False)
+    for s in vdc:
+        idx = numpy.digitize((s,), check_bins)
+        if is_checked[idx]:
+            continue
 
-        # If required, return the actual end-point value (a float) as
-        # the 2nd sample point to be returned. Then the next sample
-        # point is the end-point rounded to step-size.
-        if count == 1:
-            if leftover_time > (step / 2.0):
-                yield float(end)
+        is_checked[idx] = True
+        yield float(check_bins[idx])
 
-        count = count + 1
-        while True:
-            if times_sampled[idx] is False:
-                times_sampled[idx] = True
-                yield float(idx)
-                break
-            else:
-                # We have already sampled at this value of t,
-                # so lets try a different value of t.
-                decimals = (s % 1)
-                if decimals < 0.5:
-                    idx = idx - step
-                    if (idx < 0):  # handle wrap past zero
-                        idx = int(end - 1)
-                else:
-                    idx = idx + step
-                    if (idx > end):  # handle wrap past end
-                        idx = int(start + 1)
+        if numpy.all(is_checked):
+            return
 
 
 def GetCollisionCheckPts(robot, traj, include_start=True, start_time=0.,

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1541,15 +1541,15 @@ def VanDerCorputSampleGenerator(start, end, step=2):
     # Return a collision-checking sequence that eventually covers the range.
     vdc = VanDerCorputSequence(lower=start, upper=end, include_endpoints=False)
     for s in vdc:
+        if numpy.all(is_checked):
+            return
+
         idx = numpy.digitize((s,), check_bins)
         if is_checked[idx]:
             continue
 
         is_checked[idx] = True
         yield float(check_bins[idx])
-
-        if numpy.all(is_checked):
-            return
 
 
 def GetCollisionCheckPts(robot, traj, include_start=True, start_time=0.,

--- a/tests/test_util.py
+++ b/tests/test_util.py
@@ -468,42 +468,42 @@ class Tests(unittest.TestCase):
     #  for getting sample points to be collision-checked.)
 
     def test_VanDerCorputSampleGenerator_ExcessLessThanHalfStep(self):
-        # Check that the end-point is included when it's
+        # Check that the end-point is included when its
         # more than half the step-size from the closest value.
-        expected_sequence = [0.0, 13.7, 12.0, 6.0, 4.0, 8.0, 2.0, 10.0]
+        expected_sequence = [0., 13.7, 8., 4., 12., 2., 10., 6.]
         traj_dur = 13.7
         vdc_seq = prpy.util.VanDerCorputSampleGenerator(0.0, traj_dur, step=2)
         seq_list = [s for s in vdc_seq]
         error = 'The sequence ' + str(seq_list) + \
                 ' doesnt match the expected sequence ' + str(expected_sequence)
-        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence, \
-                                                decimal=7, err_msg=error, \
+        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence,
+                                                decimal=7, err_msg=error,
                                                 verbose=True)
 
     def test_VanDerCorputSampleGenerator_ExcessEqualToHalfStep(self):
-        # Check that the end-point is NOT included when it's distance 
-        # is EQUAL too (or less than) the step-size.
-        expected_sequence = [0.0, 12.0, 6.0, 4.0, 8.0, 2.0, 10.0]
+        # Check that the end-point is included when its distance
+        # is EQUAL to (or less than) the step-size.
+        expected_sequence = [0., 13., 8., 4., 10., 2., 6., 12.]
         traj_dur = 13.0
         vdc_seq = prpy.util.VanDerCorputSampleGenerator(0.0, traj_dur, step=2)
         seq_list = [s for s in vdc_seq]
         error = 'The sequence ' + str(seq_list) + \
                 ' doesnt match the expected sequence ' + str(expected_sequence)
-        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence, \
-                                                decimal=7, err_msg=error, \
+        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence,
+                                                decimal=7, err_msg=error,
                                                 verbose=True)
 
     def test_VanDerCorputSampleGenerator_NoExcess(self):
         # Check when the step-size fits exactly into the duration of the
         # trajectory, also check when function inputs are integers.
-        expected_sequence = [0.0, 12.0, 6.0, 4.0, 8.0, 2.0, 10.0]
+        expected_sequence = [0., 12., 6., 4., 10., 2., 8.]
         traj_duratn = 12
         vdc_seq = prpy.util.VanDerCorputSampleGenerator(0, traj_duratn, step=2)
         seq_list = [s for s in vdc_seq]
         error = 'The sequence ' + str(seq_list) + \
                 ' doesnt match the expected sequence ' + str(expected_sequence)
-        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence, \
-                                                decimal=7, err_msg=error, \
+        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence,
+                                                decimal=7, err_msg=error,
                                                 verbose=True)
 
     def test_VanDerCorputSampleGenerator_StepSizeSnapping(self):
@@ -513,15 +513,15 @@ class Tests(unittest.TestCase):
         # That is, the 3rd value of the expected sequence is '6'
         # (instead of 5.5) because we need the Sample Generate to
         # snap all sequence values to the step-size.
-        expected_sequence = [0.0, 11.0, 6.0, 3.0, 8.0, 1.0, \
-                                                 7.0, 4.0, 10.0, 2.0, 5.0, 9.0]
+        expected_sequence = [0, 11, 6.0, 3.0, 9.0, 2.0, 7.0,
+                             5.0, 10.0, 1.0, 4.0, 8.0]
         traj_duratn = 11
         vdc_seq = prpy.util.VanDerCorputSampleGenerator(0, traj_duratn, step=1)
         seq_list = [s for s in vdc_seq]
         error = 'The sequence ' + str(seq_list) + \
                 ' doesnt match the expected sequence ' + str(expected_sequence)
-        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence, \
-                                                decimal=7, err_msg=error, \
+        numpy.testing.assert_array_almost_equal(seq_list, expected_sequence,
+                                                decimal=7, err_msg=error,
                                                 verbose=True)
 
 


### PR DESCRIPTION
This refactors VanDerCorputSampleGenerator to include the start and end (goal) values as the first two samples to be checked, followed by the discretized intermediate checks within the interval range.

This is an alternate way to address #297 and #303, but avoids the non-termination problem introduced in #303 by simplifying the generator loop.  The resulting output should be identical to the expected output of #303.

**@mkoval @DavidB-CMU let's continue the discussion from #303 here.**