### PR TITLE
Move ros_control_client_py to optional dependency

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -34,7 +34,6 @@
   <run_depend>python-rospkg</run_depend>
   <run_depend>python-yaml</run_depend>
   <run_depend>python-lxml</run_depend>
-  <run_depend>ros_control_client_py</run_depend>
   <test_depend>python-nose</test_depend>
   <!-- These optional dependencies cause unit tests can fail if missing. -->
   <test_depend>cbirrt2</test_depend>

--- a/src/prpy/__init__.py
+++ b/src/prpy/__init__.py
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
-import base, controllers, dependency_manager, logger, ik_ranking, planning, perception, simulation, tsr, viz
+import base, dependency_manager, logger, ik_ranking, planning, perception, simulation, tsr, viz
 from named_config import ConfigurationLibrary
 from clone import Clone, Cloned
 from bind import bind_subclass

--- a/src/prpy/controllers/position_command_controller.py
+++ b/src/prpy/controllers/position_command_controller.py
@@ -1,8 +1,5 @@
 import logging
-
 from . import OrController
-from ros_control_client_py import SetPositionClient, SetPositionFailed
-from ros_control_client_py.util import or_to_ros_trajectory
 
 
 class PositionCommandController(OrController):
@@ -16,6 +13,7 @@ class PositionCommandController(OrController):
         if simulated:
             raise NotImplementedError('Simulation not supported on '
                                       'PositionCommandController')
+        from ros_control_client_py import SetPositionClient
         self.logger = logging.getLogger(__name__)
         self.namespace = namespace
         self.controller_name = controller_name
@@ -26,6 +24,7 @@ class PositionCommandController(OrController):
                          .format(namespace, controller_name))
 
     def SetDesired(self, position):
+        from ros_control_client_py import SetPositionFailed
         if not self.IsDone():
             raise SetPositionFailed('PositionCommand action already '
                                     'in progress and cannot be preempted',

--- a/src/prpy/controllers/rewd_controllers.py
+++ b/src/prpy/controllers/rewd_controllers.py
@@ -1,8 +1,5 @@
 import logging
 
-from ros_control_client_py import FollowJointTrajectoryClient, TrajectoryExecutionFailed
-from ros_control_client_py.util import or_to_ros_trajectory
-
 
 class OrController(object):
     """Dummy/empty OpenRAVE controller class"""
@@ -65,7 +62,10 @@ class RewdOrTrajectoryController(RewdOrController):
                                                          joint_names,
                                                          simulated)
         if simulated:
-            raise NotImplementedError('Simulation not supported in RewdOrTrajectoryController')
+            raise NotImplementedError('Simulation not supported in '
+                                      'RewdOrTrajectoryController')
+
+        from ros_control_client_py import FollowJointTrajectoryClient
 
         self.controller_client = FollowJointTrajectoryClient(namespace,
                                                              controller_name)
@@ -73,15 +73,20 @@ class RewdOrTrajectoryController(RewdOrController):
         self.logger.info('Rewd Trajectory Controller initialized')
 
     def SetPath(self, traj):
+        from ros_control_client_py import TrajectoryExecutionFailed
+        from ros_control_client_py.util import or_to_ros_trajectory
         if not self.IsDone():
-            raise TrajectoryExecutionFailed('Currently executing another trajectory', traj, None)
+            raise TrajectoryExecutionFailed('Currently executing another '
+                                            'trajectory', traj, None)
 
         ros_traj = or_to_ros_trajectory(self.GetRobot(), traj)
         self.current_trajectory = self.controller_client.execute(ros_traj)
 
     def IsDone(self):
-        return self.current_trajectory is None or self.current_trajectory.done()
+        return (self.current_trajectory is None or
+                self.current_trajectory.done())
 
     def GetTime(self):
         # TODO implement with self.current_trajectory.partial_result()
-        raise NotImplementedError('GetTime not yet implemented in RewdOrTrajectoryController')
+        raise NotImplementedError('GetTime not yet implemented in '
+                                  'RewdOrTrajectoryController')

--- a/src/prpy/controllers/trigger_controller.py
+++ b/src/prpy/controllers/trigger_controller.py
@@ -1,7 +1,6 @@
 import logging
 
 from . import OrController
-from ros_control_client_py import TriggerClient, TriggerFailed
 
 
 class TriggerController(OrController):
@@ -17,6 +16,7 @@ class TriggerController(OrController):
         self._current_cmd = None
         self.simulated = simulated
         if not simulated:
+            from ros_control_client_py import TriggerClient
             self.controller_client = TriggerClient(namespace, controller_name)
         self.logger.info("Trigger Controller initialized")
 
@@ -26,7 +26,11 @@ class TriggerController(OrController):
         :param timeout: if not None, block until timeout
         :type timeout: double or None
         """
+        if self.simulated:
+            pass
+
         if not self.IsDone():
+            from ros_control_client_py import TriggerFailed
             raise TriggerFailed("Trigger action already \
                                      in progress and cannot be preempted",
                                 None)


### PR DESCRIPTION
This is the standard way we do this, right @psigen / @mkoval? Just import inside a function after a check?
Addresses #307 