### PR TITLE
Save list of log handlers before removing them.

### DIFF
--- a/src/prpy/logger.py
+++ b/src/prpy/logger.py
@@ -53,7 +53,7 @@ def initialize_logging():
 
     # Remove all of the existing handlers.
     base_logger = logging.getLogger()
-    for handler in base_logger.handlers:
+    for handler in list(base_logger.handlers):
         base_logger.removeHandler(handler)
 
     # Add the custom handler.


### PR DESCRIPTION
There is a bug in `prpy.logger.initialize_logging` where loggers are not fully removed by:
https://github.com/personalrobotics/prpy/blob/master/src/prpy/logger.py#L56

I think this is because the `handlers` property is doing odd stuff as it is iterated if `removeHandler` is called.

Here's an example of this code not working consistently:
```python
# Supposedly remove all of the existing handlers.
base_logger = logging.getLogger()
print "Starting with these handlers: ", base_logger.handlers
for handler in base_logger.handlers:
    print "Removing: ", handler
    base_logger.removeHandler(handler)
print "Finishing with these handlers: ", base_logger.handlers
```
```
Starting with these handlers:  [<logging.StreamHandler object at 0x7fdb65567850>, <logging.StreamHandler object at 0x7fdb65567910>, <logging.StreamHandler object at 0x7fdb65567a10>, <logging.StreamHandler object at 0x7fdb65567ad0>]
# Removing:  <logging.StreamHandler object at 0x7fdb65567850>
# Removing:  <logging.StreamHandler object at 0x7fdb65567a10>
# Finishing with these handlers:  [<logging.StreamHandler object at 0x7fdb65567910>, <logging.StreamHandler object at 0x7fdb65567ad0>]
```