### PR TITLE
Fix CHOMP DistanceFieldManager field generation to properly disable other kinbodies

### DIFF
--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -90,10 +90,8 @@ class DistanceFieldManager(object):
                     for other_body in self.env.GetBodies():
                         if other_body == body:
                             continue
-                        if not other_body.IsEnabled():
-                            continue
                         other_bodies.append(other_body)
-                    other_savers = map(openravepy.KinBodyStateSaver, other_bodies)
+                    other_savers = [openravepy.KinBodyStateSaver(body,openravepy.KinBody.SaveParameters.LinkEnable) for body in other_bodies]
                     with contextlib.nested(*other_savers):
                         for other_body in other_bodies:
                             other_body.Enable(False)

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -91,7 +91,7 @@ class DistanceFieldManager(object):
                         if other_body == body:
                             continue
                         other_bodies.append(other_body)
-                    other_savers = [openravepy.KinBodyStateSaver(body,openravepy.KinBody.SaveParameters.LinkEnable) for body in other_bodies]
+                    other_savers = [openravepy.KinBodyStateSaver(other_body,openravepy.KinBody.SaveParameters.LinkEnable) for other_body in other_bodies]
                     with contextlib.nested(*other_savers):
                         for other_body in other_bodies:
                             other_body.Enable(False)

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 
 import collections
+import contextlib
 import logging
 import numpy
 import openravepy
@@ -84,7 +85,20 @@ class DistanceFieldManager(object):
                         body_name, os.path.basename(cache_path)
                     )
 
-                    self.module.computedistancefield(body, cache_filename=cache_path)
+                    # Temporarily disable other bodies for distance field computation
+                    other_bodies = []
+                    for other_body in self.env.GetBodies():
+                        if other_body == body:
+                            continue
+                        if not other_body.IsEnabled():
+                            continue
+                        other_bodies.append(other_body)
+                    other_savers = map(openravepy.KinBodyStateSaver, other_bodies)
+                    with contextlib.nested(*other_savers):
+                        for other_body in other_bodies:
+                            other_body.Enable(False)
+                        self.module.computedistancefield(body, cache_filename=cache_path)
+
                     self.cache[body_name] = current_state
                     num_recomputed += 1
                 else:


### PR DESCRIPTION
When the CHOMP module computes a distance field attached to a kinbody, it does not internally disable other kinbodies during collision checking (this enables multiple bodies to be included in one field, which you often want).  However, the `DistanceFieldManager` assumes that there is one field per kinbody ... but when generating that field, it was not properly disabling other kinbodies.  This led to incorrect fields and poor CHOMP performance in `prpy`.  This PR fixes this bug.