### PR TITLE
Truncate DOF values to 5 decimal places for CHOMP SDF hashing

### DIFF
--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -132,7 +132,8 @@ class DistanceFieldManager(object):
             kinematics_hash = body.GetKinematicsGeometryHash(),
             enabled_mask = tuple(enabled_mask),
             dof_indices = tuple(dof_indices),
-            dof_values = tuple(body.GetDOFValues(dof_indices)),
+            # adding zero does -0.0 -> 0.0
+            dof_values = tuple([round(v,5)+0 for v in body.GetDOFValues(dof_indices)]),
         )
 
     @staticmethod


### PR DESCRIPTION
Gilwoo found that the tableclearing demo required many different hashed SDFs for HERB, even between the majority of plans in which the right arm is moving, with the left arm in its starting configuration.  After some investigation, we found that the values for non-active DOFs were changing very slightly (especially noticeable around zero).  This PR snaps the DOF values to the nearest 5th decimal digit (and handles values around zero).  This doesn't avoid the general problem of hashing floating point values, but does mitigate it in many cases where non-active configurations are read from decimal-formatted model and configuration files.