### PR TITLE
Fix to remove deprecationwarning

### DIFF
--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1545,10 +1545,11 @@ def VanDerCorputSampleGenerator(start, end, step=2):
             return
 
         idx = numpy.digitize((s,), check_bins, right=True)
-        if is_checked[idx]:
+        assert idx.shape == (1,)
+        if is_checked[idx[0]]:
             continue
 
-        is_checked[idx] = True
+        is_checked[idx[0]] = True
         yield float(check_bins[idx])
 
 


### PR DESCRIPTION
Fix to remove the following prints:
```
DeprecationWarning: converting an array with ndim > 0 to an index will result in an error in the future
  is_checked[idx] = True
```