### PR TITLE
Lazier TSRPlanner refactor

### DIFF
--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -96,7 +96,7 @@ class TSRPlanner(BasePlanner):
         @param robot the robot whose active manipulator will be used
         @param tsrchains a list of TSR chains that define a goal set
         @param num_attempts the maximum number of planning attempts to make
-        @param candidate_size the number of candidates to consider per chunk
+        @param num_candidates the number of candidates to consider per chunk
         @param chunk_size the number of sampled goals to use per planning call
         @param tsr_timeout the maximum time to spend sampling goal TSR chains
         @param ranker an IK ranking function to use over the IK solutions

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -145,7 +145,6 @@ class TSRPlanner(BasePlanner):
 
         # Configure the robot to use the active manipulator for planning.
         from openravepy import CollisionOptions, CollisionOptionsStateSaver
-
         p = openravepy.KinBody.SaveParameters
         with robot.CreateRobotStateSaver(p.ActiveDOF),\
               CollisionOptionsStateSaver(self.env.GetCollisionChecker(), 
@@ -153,7 +152,11 @@ class TSRPlanner(BasePlanner):
             
             robot.SetActiveDOFs(manipulator.GetArmIndices())
 
+            # Attempt num_attempts planning attempts
             for i_attempt in xrange(num_attempts):
+
+                # Build a set of the next chunk_size collision-free
+                # IK solutions (considered in ranked order).
                 ik_set = []
                 while len(ik_set) < chunk_size and ranked_ik_solutions:
                     ik_solution = ranked_ik_solutions.pop(0)
@@ -162,7 +165,6 @@ class TSRPlanner(BasePlanner):
                         ik_set.append(ik_solution)
 
                 # Try planning to each solution set in descending cost order.
-                # for i, ik_set in ik_set_list:
                 try:
                     if len(ik_set) > 1: 
                         traj = delegate_planner.PlanToConfigurations(

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -62,9 +62,9 @@ class TSRPlanner(BasePlanner):
     """
 
     @ClonedPlanningMethod
-    def PlanToTSR(self, robot, tsrchains, tsr_timeout=2.0,
+    def PlanToTSR(self, robot, tsrchains, tsr_timeout=0.5,
                   num_attempts=3, chunk_size=1, ranker=None,
-                  max_deviation=2 * numpy.pi, **kw_args):
+                  max_deviation=2 * numpy.pi, num_samples=10, **kw_args):
         """
         Plan to a desired TSR set using a-priori goal sampling.  This planner
         samples a fixed number of goals from the specified TSRs up-front, then
@@ -110,8 +110,8 @@ class TSRPlanner(BasePlanner):
 
         # Create an iterator that cycles TSR chains until the timelimit.
         tsr_timelimit = time.time() + tsr_timeout
-        tsr_sampler = itertools.takewhile(
-            lambda v: time.time() < tsr_timelimit, tsr_cycler)
+        tsr_sampler = itertools.islice(itertools.takewhile(
+            lambda v: time.time() < tsr_timelimit, tsr_cycler), num_samples)
 
         # Sample a list of TSR poses and collate valid IK solutions.
         from openravepy import (IkFilterOptions,
@@ -122,7 +122,7 @@ class TSRPlanner(BasePlanner):
             ik_param = IkParameterization(
                 tsrchain.sample(), IkParameterizationType.Transform6D)
             ik_solution = manipulator.FindIKSolutions(
-                ik_param, IkFilterOptions.CheckEnvCollisions,
+                ik_param, IkFilterOptions.IgnoreSelfCollisions,
                 ikreturn=False, releasegil=True
             )
             if ik_solution.shape[0] > 0:
@@ -141,41 +141,46 @@ class TSRPlanner(BasePlanner):
         valid_solutions = ik_solutions[valid_idxs, :]
         ranked_indices = numpy.argsort(valid_scores)
         ranked_ik_solutions = valid_solutions[ranked_indices, :]
-
-        # Group the IK solutions into sets of the specified size
-        # (plan for each set of IK solutions together).
-        ranked_ik_solution_sets = [
-            ranked_ik_solutions[i:i + chunk_size, :]
-            for i in range(0, ranked_ik_solutions.shape[0], chunk_size)
-        ]
-
-        num_attempts = min(len(ranked_ik_solution_sets), num_attempts)
-        ik_set_list = enumerate(ranked_ik_solution_sets[:num_attempts])
+        ranked_ik_solutions = list(ranked_ik_solutions)
 
         # Configure the robot to use the active manipulator for planning.
+        from openravepy import CollisionOptions, CollisionOptionsStateSaver
+
         p = openravepy.KinBody.SaveParameters
-        with robot.CreateRobotStateSaver(p.ActiveDOF):
+        with robot.CreateRobotStateSaver(p.ActiveDOF),\
+              CollisionOptionsStateSaver(self.env.GetCollisionChecker(), 
+                                         CollisionOptions.ActiveDOFs):
+            
             robot.SetActiveDOFs(manipulator.GetArmIndices())
 
-            # Try planning to each solution set in descending cost order.
-            for i, ik_set in ik_set_list:
+            for i_attempt in xrange(num_attempts):
+                ik_set = []
+                while len(ik_set) < chunk_size and ranked_ik_solutions:
+                    ik_solution = ranked_ik_solutions.pop(0)
+                    robot.SetActiveDOFValues(ik_solution)
+                    if not self.env.CheckCollision(robot) and not robot.CheckSelfCollision():
+                        ik_set.append(ik_solution)
+
+                # Try planning to each solution set in descending cost order.
+                # for i, ik_set in ik_set_list:
                 try:
-                    if ik_set.shape[0] > 1:
+                    if len(ik_set) > 1: 
                         traj = delegate_planner.PlanToConfigurations(
                             robot, ik_set, **kw_args)
-                    else:
+                    elif len(ik_set) == 1:
                         traj = delegate_planner.PlanToConfiguration(
                             robot, ik_set[0], **kw_args)
-
-                    logger.info('Planned to IK solution set %d of %d.',
-                                i + 1, num_attempts)
+                    else:
+                        break
+                    logger.info('Planned to IK solution set attempt %d of %d.',
+                                i_attempt + 1, num_attempts)
                     return traj
                 except PlanningError as e:
                     logger.warning(
-                        'Planning to IK solution set %d of %d failed: %s',
-                        i + 1, num_attempts, e)
+                        'Planning to IK solution set attempt %d of %d failed: %s',
+                        i_attempt + 1, num_attempts, e)
 
         # If none of the planning attempts succeeded, report failure.
         raise PlanningError(
-            'Planning to the top {:d} of {:d} IK solution sets failed.'
-            .format(num_attempts, len(ranked_ik_solution_sets)))
+            'Planning to the top {:d} IK solution sets failed.'
+            .format(i_attempt + 1))

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -214,7 +214,7 @@ class TSRPlanner(BasePlanner):
                 return traj
             except PlanningError as e:
                 logger.warning('Planning attempt %d of %d failed: %s',
-                    i_attempt + 1, num_attempts, e)
+                    iattempt + 1, num_attempts, e)
 
         raise PlanningError('Failed to find a solution in {:d} attempts.'.format(
             iattempt + 1))

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -136,9 +136,11 @@ class TSRPlanner(BasePlanner):
             return ik_solutions
 
         def is_configuration_valid(ik_solution):
-            robot.SetActiveDOFValues(ik_solution)
-            return (not self.env.CheckCollision(robot)
-                and not robot.CheckSelfCollision())
+            p = openravepy.KinBody.SaveParameters
+            with robot.CreateRobotStateSaver(p.LinkTransformation):
+                robot.SetActiveDOFValues(ik_solution)
+                return (not self.env.CheckCollision(robot)
+                    and not robot.CheckSelfCollision())
 
         def is_time_available(*args):
             # time_start and time_expired are defined below.

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -32,7 +32,6 @@ import time
 import itertools
 import numpy
 import openravepy
-import warnings
 from base import (BasePlanner, ClonedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
 from openravepy import (
@@ -83,7 +82,7 @@ class TSRPlanner(BasePlanner):
     @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=0.5,
                   num_attempts=3, chunk_size=1, num_candidates=50, ranker=None,
-                  max_deviation=2 * numpy.pi, num_samples=None, **kw_args):
+                  max_deviation=2 * numpy.pi, **kw_args):
         """
         Plan to a desired TSR set using a-priori goal sampling.  This planner
         samples a fixed number of goals from the specified TSRs up-front, then
@@ -97,7 +96,7 @@ class TSRPlanner(BasePlanner):
         @param robot the robot whose active manipulator will be used
         @param tsrchains a list of TSR chains that define a goal set
         @param num_attempts the maximum number of planning attempts to make
-        @param num_candidates the number of candidates to consider per chunk
+        @param num_candidates the number of candidate IK solutions to rank
         @param chunk_size the number of sampled goals to use per planning call
         @param tsr_timeout the maximum time to spend sampling goal TSR chains
         @param ranker an IK ranking function to use over the IK solutions
@@ -105,10 +104,6 @@ class TSRPlanner(BasePlanner):
                              that can be considered a valid sample.
         @return traj a trajectory that satisfies the specified TSR chains
         """
-        if num_samples is not None:
-            warnings.warn('num_samples is deprecated and has no effect.',
-                DeprecationWarning)
-
         # Delegate to robot.planner by default.
         delegate_planner = self.delegate_planner or robot.planner
 

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -108,14 +108,13 @@ class TSRPlanner(BasePlanner):
         delegate_planner = self.delegate_planner or robot.planner
 
         # Plan using the active manipulator.
-        with robot.GetEnv():
-            manipulator = robot.GetActiveManipulator()
+        manipulator = robot.GetActiveManipulator()
 
-            # Distance from current configuration is default ranking.
-            if ranker is None:
-                from ..ik_ranking import NominalConfiguration
-                ranker = NominalConfiguration(manipulator.GetArmDOFValues(),
-                                              max_deviation=max_deviation)
+        # Distance from current configuration is default ranking.
+        if ranker is None:
+            from ..ik_ranking import NominalConfiguration
+            ranker = NominalConfiguration(manipulator.GetArmDOFValues(),
+                                          max_deviation=max_deviation)
 
         # Test for tsrchains that cannot be handled.
         for tsrchain in tsrchains:

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -32,6 +32,7 @@ import time
 import itertools
 import numpy
 import openravepy
+import warnings
 from base import (BasePlanner, ClonedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
 from openravepy import (
@@ -82,7 +83,7 @@ class TSRPlanner(BasePlanner):
     @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=0.5,
                   num_attempts=3, chunk_size=1, num_candidates=50, ranker=None,
-                  max_deviation=2 * numpy.pi, num_samples=10, **kw_args):
+                  max_deviation=2 * numpy.pi, num_samples=None, **kw_args):
         """
         Plan to a desired TSR set using a-priori goal sampling.  This planner
         samples a fixed number of goals from the specified TSRs up-front, then
@@ -104,6 +105,10 @@ class TSRPlanner(BasePlanner):
                              that can be considered a valid sample.
         @return traj a trajectory that satisfies the specified TSR chains
         """
+        if num_samples is not None:
+            warnings.warn('num_samples is deprecated and has no effect.',
+                DeprecationWarning)
+
         # Delegate to robot.planner by default.
         delegate_planner = self.delegate_planner or robot.planner
 

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -34,8 +34,24 @@ import numpy
 import openravepy
 from base import (BasePlanner, ClonedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
+from openravepy import (
+    IkFilterOptions,
+    IkParameterization,
+    IkParameterizationType
+)
 
 logger = logging.getLogger(__name__)
+
+
+# Source: http://stackoverflow.com/a/8991553/111426
+def grouper(n, iterable):
+    it = iter(iterable)
+    while True:
+       chunk = tuple(itertools.islice(it, n))
+       if not chunk:
+           return
+       yield chunk
+
 
 
 class TSRPlanner(BasePlanner):
@@ -63,7 +79,7 @@ class TSRPlanner(BasePlanner):
 
     @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=0.5,
-                  num_attempts=3, chunk_size=1, ranker=None,
+                  num_attempts=3, chunk_size=1, num_candidates=50, ranker=None,
                   max_deviation=2 * numpy.pi, num_samples=10, **kw_args):
         """
         Plan to a desired TSR set using a-priori goal sampling.  This planner
@@ -78,6 +94,7 @@ class TSRPlanner(BasePlanner):
         @param robot the robot whose active manipulator will be used
         @param tsrchains a list of TSR chains that define a goal set
         @param num_attempts the maximum number of planning attempts to make
+        @param candidate_size the number of candidates to consider per chunk
         @param chunk_size the number of sampled goals to use per planning call
         @param tsr_timeout the maximum time to spend sampling goal TSR chains
         @param ranker an IK ranking function to use over the IK solutions
@@ -105,84 +122,99 @@ class TSRPlanner(BasePlanner):
                     'Cannot handle start or trajectory-wide TSR constraints.')
         tsrchains = [t for t in tsrchains if t.sample_goal]
 
-        # Create an iterator that cycles through each TSR chain.
-        tsr_cycler = itertools.cycle(tsrchains)
-
-        # Create an iterator that cycles TSR chains until the timelimit.
-        tsr_timelimit = time.time() + tsr_timeout
-        tsr_sampler = itertools.islice(itertools.takewhile(
-            lambda v: time.time() < tsr_timelimit, tsr_cycler), num_samples)
-
-        # Sample a list of TSR poses and collate valid IK solutions.
-        from openravepy import (IkFilterOptions,
-                                IkParameterization,
-                                IkParameterizationType)
-        ik_solutions = []
-        for tsrchain in tsr_sampler:
-            ik_param = IkParameterization(
-                tsrchain.sample(), IkParameterizationType.Transform6D)
-            ik_solution = manipulator.FindIKSolutions(
+        def compute_ik_solutions(tsrchain):
+            pose = tsrchain.sample()
+            ik_param = IkParameterization(pose,
+                IkParameterizationType.Transform6D)
+            ik_solutions = manipulator.FindIKSolutions(
                 ik_param, IkFilterOptions.IgnoreSelfCollisions,
-                ikreturn=False, releasegil=True
-            )
-            if ik_solution.shape[0] > 0:
-                ik_solutions.append(ik_solution)
+                ikreturn=False, releasegil=True)
 
-        if len(ik_solutions) == 0:
-            raise PlanningError('No collision-free IK solutions at goal TSRs.')
+            statistics['num_tsr_samples'] += 1
+            statistics['num_ik_solutions'] += ik_solutions.shape[0]
 
-        # Sort the IK solutions in ascending order by the costs returned by the
-        # ranker. Lower cost solutions are better and infinite cost solutions
-        # are assumed to be infeasible.
-        ik_solutions = numpy.vstack(ik_solutions)
-        scores = ranker(robot, ik_solutions)
-        valid_idxs = ~numpy.isposinf(scores)
-        valid_scores = scores[valid_idxs]
-        valid_solutions = ik_solutions[valid_idxs, :]
-        ranked_indices = numpy.argsort(valid_scores)
-        ranked_ik_solutions = valid_solutions[ranked_indices, :]
-        ranked_ik_solutions = list(ranked_ik_solutions)
+            return ik_solutions
 
-        # Configure the robot to use the active manipulator for planning.
-        from openravepy import CollisionOptions, CollisionOptionsStateSaver
-        p = openravepy.KinBody.SaveParameters
-        with robot.CreateRobotStateSaver(p.ActiveDOF),\
-              CollisionOptionsStateSaver(self.env.GetCollisionChecker(), 
-                                         CollisionOptions.ActiveDOFs):
-            
-            robot.SetActiveDOFs(manipulator.GetArmIndices())
+        def is_configuration_valid(ik_solution):
+            robot.SetActiveDOFValues(ik_solution)
+            return (not self.env.CheckCollision(robot)
+                and not robot.CheckSelfCollision())
 
-            # Attempt num_attempts planning attempts
-            for i_attempt in xrange(num_attempts):
+        def is_time_available(*args):
+            # time_start and time_expired are defined below.
+            return time.time() - time_start + time_expired < tsr_timeout
 
-                # Build a set of the next chunk_size collision-free
-                # IK solutions (considered in ranked order).
-                ik_set = []
-                while len(ik_set) < chunk_size and ranked_ik_solutions:
-                    ik_solution = ranked_ik_solutions.pop(0)
-                    robot.SetActiveDOFValues(ik_solution)
-                    if not self.env.CheckCollision(robot) and not robot.CheckSelfCollision():
-                        ik_set.append(ik_solution)
+        time_expired = 0.
+        statistics = {
+            'num_tsr_samples': 0,
+            'num_ik_solutions': 0
+        }
 
-                # Try planning to each solution set in descending cost order.
-                try:
-                    if len(ik_set) > 1: 
-                        traj = delegate_planner.PlanToConfigurations(
-                            robot, ik_set, **kw_args)
-                    elif len(ik_set) == 1:
-                        traj = delegate_planner.PlanToConfiguration(
-                            robot, ik_set[0], **kw_args)
-                    else:
-                        break
-                    logger.info('Planned to IK solution set attempt %d of %d.',
-                                i_attempt + 1, num_attempts)
-                    return traj
-                except PlanningError as e:
-                    logger.warning(
-                        'Planning to IK solution set attempt %d of %d failed: %s',
-                        i_attempt + 1, num_attempts, e)
+        configuration_generator = itertools.chain.from_iterable(
+            itertools.ifilter(
+                lambda configurations: configurations.shape[0] > 0,
+                itertools.imap(compute_ik_solutions,
+                    itertools.takewhile(
+                        is_time_available,
+                        itertools.cycle(tsrchains)))))
 
-        # If none of the planning attempts succeeded, report failure.
-        raise PlanningError(
-            'Planning to the top {:d} IK solution sets failed.'
-            .format(i_attempt + 1))
+        for iattempt in xrange(num_attempts):
+            configurations_chunk = []
+            time_start = time.time()
+
+            while is_time_available() and len(configurations_chunk) < chunk_size:
+                # Generate num_candidates candidates and rank them using the
+                # user-supplied IK ranker.
+                candidates = list(itertools.islice(configuration_generator, num_candidates))
+                if not candidates:
+                    break
+
+                candidates_scores = ranker(robot, numpy.array(candidates))
+                candidates_scored = zip(candidates_scores, candidates)
+                candidates_scored.sort(key=lambda (score, _): score)
+                candidates_ranked = [q for _, q in candidates_scored]
+
+                # Select valid IK solutions from the chunk.
+                candidates_valid = itertools.islice(
+                    itertools.ifilter(
+                        is_configuration_valid,
+                        itertools.takewhile(
+                            is_time_available,
+                            candidates_ranked)),
+                    chunk_size - len(configurations_chunk))
+                configurations_chunk.extend(candidates_valid)
+
+            time_expired += time.time() - time_start
+
+            if len(configurations_chunk) == 0:
+                raise PlanningError(
+                    'Reached TSR sampling timelimit on attempt {:d} of {:d}: Failed'
+                    ' to generate any collision free IK solutions after attempting'
+                    ' {:d} TSR samples with {:d} candidate IK solutions.'.format(
+                        iattempt + 1, num_attempts,
+                        statistics['num_tsr_samples'], statistics['num_ik_solutions']))
+            elif len(configurations_chunk) < chunk_size:
+                logger.warning(
+                    'Reached TSR sampling timelimit on attempt %d of %d: got %d'
+                    ' of %d IK solutions.',
+                    iattempt + 1, num_attempts,
+                    len(configurations_chunk), chunk_size)
+
+            try:
+                logger.info('Planning attempt %d of %d to a set of %d IK solution(s).',
+                    iattempt + 1, num_attempts, len(configurations_chunk))
+
+                if chunk_size == 1:
+                    traj = delegate_planner.PlanToConfiguration(
+                        robot, configurations_chunk[0], **kw_args)
+                else:
+                    traj = delegate_planner.PlanToConfigurations(
+                        robot, configurations_chunk, **kw_args)
+
+                return traj
+            except PlanningError as e:
+                logger.warning('Planning attempt %d of %d failed: %s',
+                    i_attempt + 1, num_attempts, e)
+
+        raise PlanningError('Failed to find a solution in {:d} attempts.'.format(
+            iattempt + 1))


### PR DESCRIPTION
This supersedes #321 by making both IK generation **and** collision checking lazy.

The algorithm now looks like this:

1. Generate a set of `num_candidates` IK solutions without collision checking.
2. Rank the set of candidates by a user-provided score function.
3. Iteratively collision check the candidates in rank order until `chunk_size` are collision free.
4. If necessary, repeat (1)-(3) until the chunk is full or we reach a user-defined time limit.
5. Attempt to `PlanToConfigurations` to the chunk.
6. Repeat (1)-(5) `num_attempts` times.

Note that the sampling timeout is shared _across all attempts_. We may try fewer than `num_attempts` planning queries if we are unable to generate collision free samples quickly enough.