### PR TITLE
Add metadata about determinism to the planning pipeline

### DIFF
--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -360,7 +360,8 @@ class Sequence(MetaPlanner):
 
                 errors[planner] = e
 
-        raise MetaPlanningError('All planners failed.', errors)
+        raise MetaPlanningError(
+            'All planners failed.', errors, deterministic=is_sequence_deterministic)
 
 
 class Ranked(MetaPlanner):

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -83,6 +83,17 @@ class Tags(object):
     The amount of time that was spent actually running a trajectory.
     """
 
+    DETERMINISTIC_TRAJECTORY = 'deterministic'
+    """
+    Whether repeating the same planning query will produce the same trajectory.
+    """
+
+    DETERMINISTIC_ENDPOINT = 'deterministic_endpoint'
+    """
+    Whether repeating the same planning query will produce a trajectory with
+    the same endpoint as this trajectory.
+    """
+
 
 class LockedPlanningMethod(object):
     """

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -190,6 +190,9 @@ class CBiRRTPlanner(BasePlanner):
              extra_args=None, **kw_args):
         from openravepy import CollisionOptions, CollisionOptionsStateSaver
 
+        is_endpoint_deterministic = True
+        is_constrained = False
+
         # TODO We may need this work-around because CBiRRT doesn't like it
         # when an IK solver other than GeneralIK is loaded (e.g. nlopt_ik).
         # self.ClearIkSolver(robot.GetActiveManipulator())
@@ -252,9 +255,17 @@ class CBiRRTPlanner(BasePlanner):
 
                 args += ['jointgoals'] + self.serialize_dof_values(goal_config)
 
+            if len(jointgoals) > 1:
+                is_endpoint_deterministic = False
+
         if tsr_chains is not None:
             for tsr_chain in tsr_chains:
                 args += ['TSRChain', SerializeTSRChain(tsr_chain)]
+
+                if tsr_chain.sample_goal:
+                    is_endpoint_deterministic = False
+                if tsr_chain.constrain:
+                    is_constrained = True
 
         # FIXME: Why can't we write to anything other than cmovetraj.txt or
         # /tmp/cmovetraj.txt with CBiRRT?
@@ -276,10 +287,14 @@ class CBiRRTPlanner(BasePlanner):
                 self.env, 'GenericTrajectory')
             traj.deserialize(traj_xml)
 
-        # Tag the trajectory as constrained if a constraint TSR is present.
-        if (tsr_chains is not None and
-                any(tsr_chain.constrain for tsr_chain in tsr_chains)):
-            SetTrajectoryTags(traj, {Tags.CONSTRAINED: True}, append=True)
+        # Tag the trajectory as non-determistic since CBiRRT is a randomized
+        # planner. Additionally tag the goal as non-deterministic if CBiRRT
+        # chose from a set of more than one goal configuration.
+        SetTrajectoryTags(traj, {
+            Tags.CONSTRAINED: is_constrained,
+            Tags.DETERMINISTIC_TRAJECTORY: False,
+            Tags.DETERMINISTIC_ENDPOINT: is_endpoint_deterministic,
+        }, append=True)
 
         # Strip extraneous groups from the output trajectory.
         # TODO: Where are these groups coming from!?

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -278,7 +278,8 @@ class CBiRRTPlanner(BasePlanner):
             response = self.problem.SendCommand(args_str, True)
 
         if not response.strip().startswith('1'):
-            raise PlanningError('Unknown error: ' + response)
+            raise PlanningError('Unknown error: ' + response,
+                deterministic=False)
 
         # Construct the output trajectory.
         with open(traj_path, 'rb') as traj_file:

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -283,6 +283,13 @@ class CHOMPPlanner(BasePlanner):
                 elif robot.CheckSelfCollision(report=report):
                     raise SelfCollisionPlanningError.FromReport(report)
 
-        SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
+        # Tag the trajectory as non-determistic since CBiRRT is a randomized
+        # planner. Additionally tag the goal as non-deterministic if CBiRRT
+        # chose from a set of more than one goal configuration.
+        SetTrajectoryTags(traj, {
+            Tags.SMOOTH: True,
+            Tags.DETERMINISTIC_TRAJECTORY: not kwargs.get('use_hmc', False),
+            Tags.DETERMINISTIC_ENDPOINT: True
+        }, append=True)
 
         return traj

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -121,8 +121,9 @@ class OMPLPlanner(BasePlanner):
 
             if status not in [PlannerStatus.HasSolution,
                               PlannerStatus.InterruptedWithSolution]:
-                raise PlanningError('Planner returned with status {0:s}.'
-                                    .format(str(status)))
+                raise PlanningError(
+                    'Planner returned with status {:s}.'.format(str(status)),
+                    deterministic=False)
 
         # Tag the trajectory as non-determistic since most OMPL planners are
         # randomized. Additionally tag the goal as non-deterministic if OMPL

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -81,9 +81,9 @@ class OMPLPlanner(BasePlanner):
         @param tsrchains A list of tsrchains to use during planning
         @param return traj
         """
-        return self._TSRPlan(robot, tsrchains, **kw_args)
+        return self._Plan(robot, tsrchains=tsrchains, **kw_args)
 
-    def _Plan(self, robot, goal=None, timeout=30., shortcut_timeout=5.,
+    def _Plan(self, robot, goal=None, tsrchains=None, timeout=30., shortcut_timeout=5.,
               continue_planner=False, ompl_args=None,
               formatted_extra_params=None, **kw_args):
         extraParams = '<time_limit>{:f}</time_limit>'.format(timeout)
@@ -92,6 +92,11 @@ class OMPLPlanner(BasePlanner):
             for key, value in ompl_args.iteritems():
                 extraParams += '<{k:s}>{v:s}</{k:s}>'.format(
                     k=str(key), v=str(value))
+
+        if tsrchains is not None:
+            for chain in tsrchains:
+                extraParams += '<{k:s}>{v:s}</{k:s}>'.format(
+                    k='tsr_chain', v=SerializeTSRChain(chain))
 
         if formatted_extra_params is not None:
             extraParams += formatted_extra_params
@@ -119,15 +124,15 @@ class OMPLPlanner(BasePlanner):
                 raise PlanningError('Planner returned with status {0:s}.'
                                     .format(str(status)))
 
+        # Tag the trajectory as non-determistic since most OMPL planners are
+        # randomized. Additionally tag the goal as non-deterministic if OMPL
+        # chose from a set of more than one goal configuration.
+        SetTrajectoryTags(traj, {
+            Tags.DETERMINISTIC_TRAJECTORY: False,
+            Tags.DETERMINISTIC_ENDPOINT: tsrchains is None,
+        }, append=True)
+
         return traj
-
-    def _TSRPlan(self, robot, tsrchains, **kw_args):
-        extraParams = ''
-        for chain in tsrchains:
-            extraParams += '<{k:s}>{v:s}</{k:s}>'.format(
-                k='tsr_chain', v=SerializeTSRChain(chain))
-
-        return self._Plan(robot, formatted_extra_params=extraParams, **kw_args)
 
 
 class RRTConnect(OMPLPlanner):
@@ -188,7 +193,7 @@ class RRTConnect(OMPLPlanner):
         @return traj
         """
         ompl_args = self._SetPlannerRange(robot, ompl_args=ompl_args)
-        return self._TSRPlan(robot, tsrchains, ompl_args=ompl_args, **kw_args)
+        return self._Plan(robot, tsrchains=tsrchains, ompl_args=ompl_args, **kw_args)
 
 
 class OMPLSimplifier(BasePlanner):
@@ -227,5 +232,12 @@ class OMPLSimplifier(BasePlanner):
             raise PlanningError('Simplifier returned with status {0:s}.'
                                 .format(str(status)))
 
-        SetTrajectoryTags(output_path, {Tags.SMOOTH: True}, append=True)
+        # Tag the trajectory as non-deterministic since the OMPL path
+        # simplifier samples random candidate shortcuts. It does not, however,
+        # change the endpoint, so we leave DETERMINISTIC_ENDPOINT unchanged.
+        SetTrajectoryTags(output_path, {
+            Tags.SMOOTH: True,
+            Tags.DETERMINISTIC_TRAJECTORY: False,
+        }, append=True)
+
         return output_path

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -114,9 +114,9 @@ class SnapPlanner(BasePlanner):
                 robot.SetActiveDOFValues(q)
                 report = openravepy.CollisionReport()
                 if self.env.CheckCollision(robot, report=report):
-                    raise CollisionPlanningError.FromReport(report)
+                    raise CollisionPlanningError.FromReport(report, deterministic=True)
                 elif robot.CheckSelfCollision(report=report):
-                    raise SelfCollisionPlanningError.FromReport(report)
+                    raise SelfCollisionPlanningError.FromReport(report, deterministic=True)
 
             raise PlanningError('There is no IK solution at the goal pose.')
 
@@ -185,9 +185,11 @@ class SnapPlanner(BasePlanner):
                 # Check for collisions
                 report = openravepy.CollisionReport()
                 if self.env.CheckCollision(robot, report=report):
-                    raise CollisionPlanningError.FromReport(report)
+                    raise CollisionPlanningError.FromReport(
+                        report, deterministic=True)
                 elif robot.CheckSelfCollision(report=report):
-                    raise SelfCollisionPlanningError.FromReport(report)
+                    raise SelfCollisionPlanningError.FromReport(
+                        report, deterministic=True)
 
         SetTrajectoryTags(traj, {
             Tags.SMOOTH: True,

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -189,6 +189,10 @@ class SnapPlanner(BasePlanner):
                 elif robot.CheckSelfCollision(report=report):
                     raise SelfCollisionPlanningError.FromReport(report)
 
-        # Tag the return trajectory as smooth (in joint space).
-        SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
+        SetTrajectoryTags(traj, {
+            Tags.SMOOTH: True,
+            Tags.DETERMINISTIC_TRAJECTORY: True,
+            Tags.DETERMINISTIC_ENDPOINT: True,
+        }, append=True)
+
         return traj

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -118,7 +118,8 @@ class SnapPlanner(BasePlanner):
                 elif robot.CheckSelfCollision(report=report):
                     raise SelfCollisionPlanningError.FromReport(report, deterministic=True)
 
-            raise PlanningError('There is no IK solution at the goal pose.')
+            raise PlanningError(
+                'There is no IK solution at the goal pose.', deterministic=True)
 
         return self._Snap(robot, ik_solution, **kw_args)
 
@@ -138,7 +139,7 @@ class SnapPlanner(BasePlanner):
         # Check the start position is within joint limits,
         # this can throw a JointLimitError
         start = robot.GetActiveDOFValues()
-        CheckJointLimits(robot, start)
+        CheckJointLimits(robot, start, deterministic=True)
 
         # Add the start waypoint
         start_waypoint = numpy.zeros(cspec.GetDOF())
@@ -150,7 +151,7 @@ class SnapPlanner(BasePlanner):
         # Make the trajectory end at the goal configuration, as
         # long as it is not in collision and is not identical to
         # the start configuration.
-        CheckJointLimits(robot, goal)
+        CheckJointLimits(robot, goal, deterministic=True)
         if not numpy.allclose(start, goal):
             goal_waypoint = numpy.zeros(cspec.GetDOF())
             cspec.InsertJointValues(goal_waypoint, goal, robot,

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -169,6 +169,13 @@ class TSRPlanner(BasePlanner):
 
                     logger.info('Planned to IK solution set %d of %d.',
                                 i + 1, num_attempts)
+
+                    # We sampled the goal non-deterministically from the TSR.
+                    SetTrajectoryTags(traj, {
+                        Tags.DETERMINISTIC_TRAJECTORY: False,
+                        Tags.DETERMINISTIC_ENDPOINT: False,
+                    }, append=True)
+
                     return traj
                 except PlanningError as e:
                     logger.warning(

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -34,6 +34,8 @@ import numpy
 import openravepy
 from base import (BasePlanner, ClonedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
+from .base import Tags
+from ..util import SetTrajectoryTags
 
 logger = logging.getLogger(__name__)
 

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -129,7 +129,9 @@ class TSRPlanner(BasePlanner):
                 ik_solutions.append(ik_solution)
 
         if len(ik_solutions) == 0:
-            raise PlanningError('No collision-free IK solutions at goal TSRs.')
+            raise PlanningError(
+                'No collision-free IK solutions at goal TSRs.',
+                deterministic=False)
 
         # Sort the IK solutions in ascending order by the costs returned by the
         # ranker. Lower cost solutions are better and infinite cost solutions
@@ -180,9 +182,10 @@ class TSRPlanner(BasePlanner):
                 except PlanningError as e:
                     logger.warning(
                         'Planning to IK solution set %d of %d failed: %s',
-                        i + 1, num_attempts, e)
+                        i + 1, num_attempts, e,)
 
         # If none of the planning attempts succeeded, report failure.
         raise PlanningError(
             'Planning to the top {:d} of {:d} IK solution sets failed.'
-            .format(num_attempts, len(ranked_ik_solution_sets)))
+            .format(num_attempts, len(ranked_ik_solution_sets)),
+            deterministic=False)

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -589,11 +589,11 @@ class VectorFieldPlanner(BasePlanner):
                            path.Sample(t_cache),
                            cspec)
 
-        # Flag this trajectory as constrained.
-        util.SetTrajectoryTags(
-            output_path, {
-                Tags.CONSTRAINED: 'true',
-                Tags.SMOOTH: 'true'
-            }, append=True
-        )
+        util.SetTrajectoryTags(output_path, {
+            Tags.SMOOTH: True,
+            Tags.CONSTRAINED: True,
+            Tags.DETERMINISTIC_TRAJECTORY: True,
+            Tags.DETERMINISTIC_ENDPOINT: True,
+        }, append=True)
+
         return output_path

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -491,7 +491,7 @@ class VectorFieldPlanner(BasePlanner):
 
             # Check joint position limits.
             # We do this before setting the joint angles.
-            util.CheckJointLimits(robot, q)
+            util.CheckJointLimits(robot, q, deterministic=True)
 
             robot.SetActiveDOFValues(q)
 

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -498,9 +498,11 @@ class VectorFieldPlanner(BasePlanner):
             # Check collision.
             report = CollisionReport()
             if env.CheckCollision(robot, report=report):
-                raise CollisionPlanningError.FromReport(report)
+                raise CollisionPlanningError.FromReport(
+                    report, deterministic=True)
             elif robot.CheckSelfCollision(report=report):
-                raise SelfCollisionPlanningError.FromReport(report)
+                raise SelfCollisionPlanningError.FromReport(
+                    report, deterministic=True)
 
             # Check the termination condition.
             status = fn_terminate()
@@ -569,7 +571,8 @@ class VectorFieldPlanner(BasePlanner):
         exception = nonlocals['exception']
 
         if t_cache is None:
-            raise exception or PlanningError('An unknown error has occurred.')
+            raise exception or PlanningError(
+                'An unknown error has occurred.', deterministic=True)
         elif exception:
             logger.warning('Terminated early: %s', str(exception))
 

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -188,10 +188,14 @@ class GreedyIKPlanner(BasePlanner):
             try:
                 while t < traj.GetDuration() + epsilon:
                     # Check for a timeout.
+                    # TODO: This is not really deterministic because we do not
+                    # have control over CPU time. However, it is exceedingly
+                    # unlikely that running the query again will change the
+                    # outcome unless there is a significant change in CPU load.
                     current_time = time.time()
                     if (timelimit is not None and
                             current_time - start_time > timelimit):
-                        raise TimeoutPlanningError(timelimit)
+                        raise TimeoutPlanningError(timelimit, deterministic=True)
 
                     # Hypothesize new configuration as closest IK to current
                     qcurr = robot.GetActiveDOFValues()  # Configuration at t.
@@ -208,7 +212,7 @@ class GreedyIKPlanner(BasePlanner):
                         # Found an IK
                         step = abs(qnew - qcurr)
                         if (max(step) < min_step) and qtraj:
-                            raise PlanningError('Not making progress.')
+                            raise PlanningError('Not making progress.', deterministic=True)
                         infeasible_step = \
                             any(step > robot.GetActiveDOFResolutions())
                     if infeasible_step:
@@ -250,10 +254,12 @@ class GreedyIKPlanner(BasePlanner):
                             cr = CollisionReport()
                             if self.env.CheckCollision(robot, report=cr):
                                 collision_error = \
-                                    CollisionPlanningError.FromReport(cr)
+                                    CollisionPlanningError.FromReport(
+                                        cr, deterministic=True)
                             elif robot.CheckSelfCollision(report=cr):
                                 collision_error = \
-                                    SelfCollisionPlanningError.FromReport(cr)
+                                    SelfCollisionPlanningError.FromReport(
+                                        cr, deterministic=True)
                             else:
                                 collision_error = None
                     if collision_error is not None:

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -266,6 +266,10 @@ class GreedyIKPlanner(BasePlanner):
                     logger.warning('Terminated early at time %f < %f: %s',
                                    t, traj.GetDuration(), str(e))
 
-        # Return as much of the trajectory as we have solved.
-        SetTrajectoryTags(qtraj, {Tags.CONSTRAINED: True}, append=True)
+        SetTrajectoryTags(qtraj, {
+            Tags.CONSTRAINED: True,
+            Tags.DETERMINISTIC_TRAJECTORY: True,
+            Tags.DETERMINISTIC_ENDPOINT: True,
+        }, append=True)
+
         return qtraj

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1325,7 +1325,7 @@ def ComputeGeodesicUnitTiming(traj, env=None, alpha=1.0):
     return new_traj
 
 
-def CheckJointLimits(robot, q):
+def CheckJointLimits(robot, q, deterministic=None):
     """
     Check if a configuration is within a robot's joint position limits.
 
@@ -1352,7 +1352,8 @@ def CheckJointLimits(robot, q):
             dof_index=active_dof_indices[index],
             dof_value=q[index],
             dof_limit=q_limit_min[index],
-            description='position')
+            description='position',
+            deterministic=deterministic)
 
     upper_position_violations = (q > q_limit_max)
     if upper_position_violations.any():
@@ -1362,7 +1363,8 @@ def CheckJointLimits(robot, q):
             dof_index=active_dof_indices[index],
             dof_value=q[index],
             dof_limit=q_limit_max[index],
-            description='position')
+            description='position',
+            deterministic=deterministic)
 
 
 def GetForwardKinematics(robot, q, manipulator=None, frame=None):


### PR DESCRIPTION
This pull request adds three new features to the PrPy planning pipeline:

- **`DETERMINISTIC_TRAJECTORY` Trajectory Tag:** Indicates whether repeating the same planning query will produce the same trajectory
- **`DETERMINSTIC_ENDPOINT` Trajectory Tag:** Indicates whether repeating the same planning query will result in a trajectory with the same endpoint as this trajectory.
- **`determinstic` flag on `PlanningError`:** Indicates whether repeating the same planning query could result in success.

The trajectory tags default to being absent and the `deterministic` flag defaults to `None`. I strongly suggest *logging a warning* and **not** silently defaulting to `False` if they are not set. It is possible that I missed a few calls in the PrPy motion planners that we need to annotate.

This data metadata is correctly propagated by the `Sequence`, `MethodMask`, and `FirstSupported` `MetaPlanner`s. Note that the behavior of `Sequence` is a bit unintuitive: it will flag a trajectory as non-deterministic if _any previous planner in the sequence_ was non-determinstic.

There are a few additional points of subtly:

- **Seeds.** I consider the value of a random number generator seed, even if it is passed explicitly as an argument, to be non-deterministic. This is the only useful way to model randomness: _almost everything_ on a computer deterministic if we consider PRNGs to be deterministic.
- **`DETERMINSTIC_ENDPOINT` on `Sequence`.** I conservatively flag the endpoint of a trajectory as non-deterministic if a previous failure was non-deterministic. This is overly conservative for `PlanToConfiguration`, where the endpoint is _always_ deterministic.
- **Trajopt.** We need to port these changes over to `or_trajopt` separately since it lives in a separate repository.