### PR TITLE
Bugfix/get manipulator index

### DIFF
--- a/src/prpy/tsr/generic.py
+++ b/src/prpy/tsr/generic.py
@@ -1,21 +1,19 @@
 import numpy
+import warnings
 from prpy.tsr.tsrlibrary import TSRFactory
 from prpy.tsr.tsr import TSR, TSRChain
+from ..util import GetManipulatorIndex
 
 def get_manip_idx(robot, manip=None):
     """
-    Helper function for getting the manipulator index
-    to be used by the TSR
+    Helper function for getting the manipulator index to be used by the TSR.
+
+    Deprecated. Please use util.GetActiveManipulatorIndex instead.
     """
-    if manip is None:
-        manip_idx = robot.GetActiveManipulatorIndex()
-    else:
-        import openravepy
-        p = openravepy.KinBody.SaveParameters
-        with robot.CreateRobotStateSaver(p.ActiveManipulator):
-            robot.SetActiveManipulator(manip)
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
-    return manip_idx
+    warnings.warn(
+      'tsr.get_manip_idx is deprecated. Please use'
+      ' util.GetActiveManipulatorIndex instead.', DeprecationWarning)
+    return GetActiveManipulatorIndex(robot, manip)
 
 def cylinder_grasp(robot, obj, obj_radius, obj_height, 
                    lateral_offset = 0.0, 
@@ -60,7 +58,7 @@ def cylinder_grasp(robot, obj, obj_radius, obj_height,
                         'than or equal to the second (current values [%f, %f])' 
                         % (yaw_range[0], yaw_range[1]))
 
-    manip_idx = get_manip_idx(robot, manip=manip)
+    manip_idx = GetManipulatorIndex(robot, manip=manip)
 
     T0_w = obj.GetTransform()
     total_offset = lateral_offset + obj_radius
@@ -135,7 +133,7 @@ def box_grasp(robot, box, length, width, height,
     if lateral_tolerance < 0.0:
         raise Exception('lateral_tolerance must be >= 0.0')
 
-    manip_idx = get_manip_idx(robot, manip=manip)
+    manip_idx = GetManipulatorIndex(robot, manip=manip)
 
     T0_w = box.GetTransform()
 
@@ -251,7 +249,7 @@ def place_object(robot, obj, pose_tsr_chain, manip=None,
        manipulator of the robot is used
     """
 
-    manip_idx = get_manip_idx(robot, manip=manip)
+    manip_idx = GetManipulatorIndex(robot, manip=manip)
     if manip is None:
         manip = robot.GetManipulators()[manip_idx]
 
@@ -300,7 +298,7 @@ def transport_upright(robot, obj,
     if yaw_epsilon < 0.0:
         raise Exception('yaw_epsilon must be >= 0')
 
-    manip_idx = get_manip_idx(robot, manip=manip)
+    manip_idx = GetManipulatorIndex(robot, manip=manip)
     if manip is None:
         manip = robot.GetManipulators()[manip_idx]
 

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -37,6 +37,7 @@ import scipy.misc
 import scipy.optimize
 import threading
 import time
+import warnings
 
 
 logger = logging.getLogger(__name__)
@@ -2054,6 +2055,7 @@ def GetManipulatorIndex(robot, manip=None):
     @param manip The robot manipulator
     @return (manip, manip_idx) The manipulator and its index
     """
+    from openravepy import DebugLevel, RaveGetDebugLevel, RaveSetDebugLevel
 
     with robot.GetEnv():
         if manip is None:
@@ -2062,7 +2064,14 @@ def GetManipulatorIndex(robot, manip=None):
         with robot.CreateRobotStateSaver(
                 robot.SaveParameters.ActiveManipulator):
             robot.SetActiveManipulator(manip)
-            manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+
+            # Ignore GetActiveManipulatorIndex's DeprecationWarning.
+            debug_level = RaveGetDebugLevel()
+            try:
+                RaveSetDebugLevel(DebugLevel.Error)
+                manip_idx = manip.GetRobot().GetActiveManipulatorIndex()
+            finally:
+                RaveSetDebugLevel(debug_level)
 
     return (manip, manip_idx)
 


### PR DESCRIPTION
This pull request:

- Deprecates `tsr.get_manip_idx` in favor of `util.GetManipulatorIndex` since they implement the same functionality.
- Replaces all calls of `tsr.get_manip_idx` with calls to `util.GetManipulatorIndex`.
- Adds logic to `util.GetManipulatorIndex` to suppress a `DeprecationWarning`.