### PR TITLE
Add optional uri_only serialization/deserialization support, logged planner, and replay-log script

### DIFF
--- a/scripts/replay-log.py
+++ b/scripts/replay-log.py
@@ -1,0 +1,84 @@
+#!/usr/bin/python
+from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
+from __future__ import unicode_literals
+
+import argparse
+import atexit
+import math
+
+import numpy
+import openravepy
+import yaml
+
+import prpy.planning
+import prpy.serialization
+
+parser = argparse.ArgumentParser(description='replay planning request log file')
+parser.add_argument('--logfile', required=True)
+parser.add_argument('--planner', default='cbirrt', help='cbirrt OMPL_RRTConnect birrt')
+parser.add_argument('--viewer', '-v', type=str, default='interactivemarker', help='The viewer to attach (none for no viewer)')
+args = parser.parse_args()
+
+# start openrave
+openravepy.RaveInitialize(True, level=openravepy.DebugLevel.Info)
+atexit.register(openravepy.RaveDestroy)
+env = openravepy.Environment()
+atexit.register(env.Destroy)
+
+planner = None
+if args.planner == 'cbirrt':
+   planner = prpy.planning.CBiRRTPlanner()
+if args.planner == 'OMPL_RRTConnect':
+   planner = prpy.planning.ompl.OMPLPlanner('RRTConnect')
+if args.planner == 'birrt':
+   planner = prpy.planning.openrave.OpenRAVEPlanner('birrt')
+
+# read log file
+yamldict = yaml.safe_load(open(args.logfile))
+
+# deserialize environment
+prpy.serialization.deserialize_environment(yamldict['environment'], env=env)
+
+# load planning request
+try:
+   method = getattr(planner, yamldict['request']['method'])
+except AttributeError:
+   raise RuntimeError('That planner does not support planning method {}!'.format(yamldict['request']['method']))
+method_args = []
+for method_arg in yamldict['request']['args']:
+   method_args.append(prpy.serialization.deserialize(env, method_arg))
+method_kwargs = {}
+for key,value in yamldict['request']['kw_args'].items():
+   method_kwargs[key] = prpy.serialization.deserialize(env, value)
+
+# attempt to retrieve robot
+if 'robot' in method_kwargs:
+   robot = method_kwargs['robot']
+elif len(method_args) > 0:
+   robot = method_args[0]
+else:
+   raise RuntimeError('could not retrieve robot!')
+
+# load ik solver for robot in case it's needed
+ikmodel = openravepy.databases.inversekinematics.InverseKinematicsModel(robot,
+   iktype=openravepy.IkParameterizationType.Transform6D)
+if not ikmodel.load():
+   ikmodel.autogenerate()
+
+# call planning method itself ...
+print('calling planning method ...')
+traj = method(*method_args, **method_kwargs)
+
+# retime/view resulting trajectory
+if args.viewer != 'none':
+   env.SetViewer(args.viewer)
+openravepy.planningutils.RetimeActiveDOFTrajectory(traj, robot)
+try:
+   while traj is not None:
+      raw_input('Press [Enter] to run the trajectory, [Ctrl]+[C] to quit ...')
+      with env:
+         robot.GetController().SetPath(traj)
+except KeyboardInterrupt:
+   print()

--- a/scripts/replay-log.py
+++ b/scripts/replay-log.py
@@ -1,4 +1,39 @@
 #!/usr/bin/python
+
+# This script allows the planning requests produced by the Logged
+# metaplanner (using PrPy's serialization facilities) to be replayed.
+# Downstream users may need to add some additional features
+# (e.g. initializing robot-specific helpers such as HerbPy)
+# in their log replay facilities so that planners can make use of them.
+
+# Copyright (c) 2016, Carnegie Mellon University
+# All rights reserved.
+# Authors: Chris Dellin <cdellin@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of Carnegie Mellon University nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 from __future__ import absolute_import
 from __future__ import division
 from __future__ import print_function

--- a/src/prpy/planning/logged.py
+++ b/src/prpy/planning/logged.py
@@ -62,9 +62,10 @@ class LoggedPlanner(prpy.planning.base.MetaPlanner):
      - log-20160101-010203.567890.yaml
     """
 
-    def __init__(self, planner):
+    def __init__(self, planner, uri_only=True):
         super(LoggedPlanner, self).__init__()
         self.planner = planner
+        self.uri_only = uri_only
     
     def __str__(self):
         return 'Logged({0:s})'.format(self.planner)
@@ -96,7 +97,7 @@ class LoggedPlanner(prpy.planning.base.MetaPlanner):
             raise RuntimeError('could not retrieve env from planning request!')
         
         # serialize environment
-        envdict = prpy.serialization.serialize_environment(env, uri_only=True)
+        envdict = prpy.serialization.serialize_environment(env, uri_only=self.uri_only)
         
         # serialize planning request
         reqdict = {}
@@ -129,7 +130,7 @@ class LoggedPlanner(prpy.planning.base.MetaPlanner):
         
         except:
             resdict['ok'] = False
-            resdict['exception'] = 'unknown exception type'
+            resdict['exception'] = 'Unknown exception type: {}'.format(repr(sys.exc_info()[1]))
             raise
         
         finally:

--- a/src/prpy/planning/logged.py
+++ b/src/prpy/planning/logged.py
@@ -1,3 +1,33 @@
+#!/usr/bin/env python
+
+# Copyright (c) 2016, Carnegie Mellon University
+# All rights reserved.
+# Authors: Chris Dellin <cdellin@gmail.com>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of Carnegie Mellon University nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
 from __future__ import print_function
 from __future__ import unicode_literals
 from __future__ import absolute_import
@@ -13,8 +43,25 @@ import yaml
 import prpy.planning.base
 import prpy.serialization
 
+def serialize_or_errorstr(value):
+    try:
+        return prpy.serialization.serialize(value)
+    except prpy.exceptions.UnsupportedTypeSerializationException as ex:
+        return 'Error: {}'.format(str(ex))
 
 class LoggedPlanner(prpy.planning.base.MetaPlanner):
+    """Planner wrapper which serializes planning requets and responses.
+
+    LoggedPlanner delegates all planning calls to the sub-planner
+    passed to it on construction.  It does not affect the input to
+    or output from this planner.
+
+    On every request, LoggedPlanner serializes the environment,
+    planning method request arguments, and the returned trajectory.
+    It creates a timestamped yaml file in the current directory:
+     - log-20160101-010203.567890.yaml
+    """
+
     def __init__(self, planner):
         super(LoggedPlanner, self).__init__()
         self.planner = planner
@@ -56,17 +103,12 @@ class LoggedPlanner(prpy.planning.base.MetaPlanner):
         reqdict['method'] = method # string
         reqdict['args'] = []
         for arg in args:
-            try:
-                reqdict['args'].append(prpy.serialization.serialize(arg))
-            except prpy.exceptions.UnsupportedTypeSerializationException as ex:
-                reqdict['args'].append(str(ex))
+            reqdict['args'].append(serialize_or_errorstr(arg))
         reqdict['kw_args'] = {}
         for key,value in kw_args.items():
+            # if key serialization fails, it thros UnsupportedTypeSerializationException
             key = prpy.serialization.serialize(key)
-            try:
-                reqdict['kw_args'][key] = prpy.serialization.serialize(value)
-            except prpy.exceptions.UnsupportedTypeSerializationException as ex:
-                reqdict['kw_args'][key] = 'Error: ' + str(ex)
+            reqdict['kw_args'][key] = serialize_or_errorstr(value)
         
         # get ready to serialize result
         resdict = {}
@@ -77,6 +119,7 @@ class LoggedPlanner(prpy.planning.base.MetaPlanner):
             resdict['ok'] = True
             resdict['traj_first'] = list(map(float,traj.GetWaypoint(0)))
             resdict['traj_last'] = list(map(float,traj.GetWaypoint(traj.GetNumWaypoints()-1)))
+            resdict['traj'] = traj.serialize(0)
             return traj
             
         except prpy.planning.PlanningError as ex:

--- a/src/prpy/planning/logged.py
+++ b/src/prpy/planning/logged.py
@@ -1,0 +1,102 @@
+from __future__ import print_function
+from __future__ import unicode_literals
+from __future__ import absolute_import
+from __future__ import division
+import collections
+import math
+import time
+
+import openravepy
+import numpy
+import yaml
+
+import prpy.planning.base
+import prpy.serialization
+
+
+class LoggedPlanner(prpy.planning.base.MetaPlanner):
+    def __init__(self, planner):
+        super(LoggedPlanner, self).__init__()
+        self.planner = planner
+    
+    def __str__(self):
+        return 'Logged({0:s})'.format(self.planner)
+    
+    def has_planning_method(self, method_name):
+        return self.planner.has_planning_method(method_name)
+    
+    def get_planning_method_names(self):
+        return self.planner.get_planning_method_names()
+    
+    def get_planners(self, method_name):
+        return [self.planner]
+    
+    def plan(self, method, args, kw_args):
+        
+        # get log file name
+        stamp = time.time()
+        struct = time.localtime(stamp)
+        fn = 'log-{}.{:06d}.yaml'.format(
+            time.strftime('%Y%m%d-%H%M%S', struct),
+            int(1.0e6*(stamp-math.floor(stamp))))
+        
+        # retrieve enviroment
+        if 'robot' in kw_args:
+            env = kw_args['robot'].GetEnv()
+        elif len(args) > 0:
+            env = args[0].GetEnv()
+        else:
+            raise RuntimeError('could not retrieve env from planning request!')
+        
+        # serialize environment
+        envdict = prpy.serialization.serialize_environment(env, uri_only=True)
+        
+        # serialize planning request
+        reqdict = {}
+        reqdict['method'] = method # string
+        reqdict['args'] = []
+        for arg in args:
+            try:
+                reqdict['args'].append(prpy.serialization.serialize(arg))
+            except prpy.exceptions.UnsupportedTypeSerializationException as ex:
+                reqdict['args'].append(str(ex))
+        reqdict['kw_args'] = {}
+        for key,value in kw_args.items():
+            key = prpy.serialization.serialize(key)
+            try:
+                reqdict['kw_args'][key] = prpy.serialization.serialize(value)
+            except prpy.exceptions.UnsupportedTypeSerializationException as ex:
+                reqdict['kw_args'][key] = 'Error: ' + str(ex)
+        
+        # get ready to serialize result
+        resdict = {}
+        
+        try:
+            plan_fn = getattr(self.planner, method)
+            traj = plan_fn(*args, **kw_args)
+            resdict['ok'] = True
+            resdict['traj_first'] = list(map(float,traj.GetWaypoint(0)))
+            resdict['traj_last'] = list(map(float,traj.GetWaypoint(traj.GetNumWaypoints()-1)))
+            return traj
+            
+        except prpy.planning.PlanningError as ex:
+            resdict['ok'] = False
+            resdict['exception'] = str(ex)
+            raise
+        
+        except:
+            resdict['ok'] = False
+            resdict['exception'] = 'unknown exception type'
+            raise
+        
+        finally:
+            # create yaml dictionary to be serialized
+            yamldict = {}
+            yamldict['environment'] = envdict
+            yamldict['request'] = reqdict
+            yamldict['result'] = resdict
+            fp = open(fn,'w')
+            yaml.safe_dump(yamldict, fp)
+            fp.close()
+        
+        

--- a/src/prpy/serialization.py
+++ b/src/prpy/serialization.py
@@ -110,7 +110,7 @@ def serialize_kinbody(body, uri_only=False):
     if uri_only and not uri:
         serialization_logger.warn(
             'uri_only passed, but KinBody "{}"\'s GetXMLFilename()'
-            'returns an empty URI.'.format(
+            ' returns an empty URI.'.format(
             body.GetName()))
         uri_only = False
     
@@ -485,7 +485,7 @@ def deserialize_kinbody_state(body, data):
     else:
         deserialization_logger.warn(
             'KinBody "{}" does not have link_transforms/dof_branches'
-            'saved; falling back to dof_values'.format(body.GetName()))
+            ' saved; falling back to dof_values'.format(body.GetName()))
         body.SetDOFValues(data['dof_values'])
 
 def deserialize_robot_state(body, data):


### PR DESCRIPTION
This adds support for the `uri_only` flag to the PrPy serialization functions (defaults to `False`).  When this flag is set, the fixed aspects (e.g. geometry and kinematics) of kinbodies and robots in the scene that have URIs (e.g. OpenRAVE xml paths or URDF/SRDF file paths) are not serialized, and instead only the URI itself is serialized.  This is an immediate workaround for a bug in the serialization functions (or in OpenRAVE) #243 which precludes roundtripping HERB with the correct kinematics hashes, resulting in busted IK solvers.  Other advantages include reducing the size of the serialized files, and allowing planning requests to be replayed while robot or object models are modified.

This PR also contains a `Logged` planner, which takes a delegate planner, and logs both the incoming planning request and some simple data about the result, to a file.  There is also a corresponding `replay-log.py` script which allows the planning requests in these log files to be replayed.  (It is expected that downstream users, such ash HerbPy, may want to provide their own log replay facilities which can make use of robot-specific helpers and planners.)

We've been using this a bit for ISER, and it appears to be working well, so I think it's ready for a review.