### PR TITLE
Abstracted robot collision checking into class for snap and vectorfield

### DIFF
--- a/src/prpy/collision.py
+++ b/src/prpy/collision.py
@@ -98,9 +98,7 @@ class BakedRobotCollisionChecker:
 
     def CheckCollision(self, report=None):
         # The baked check is performed by checking self collision on baked
-        if self.checker.CheckSelfCollision(self.baked, report):
-            return True
-        return False
+        return self.checker.CheckSelfCollision(self.baked, report):
 
     def VerifyCollisionFree(self):
         report = openravepy.CollisionReport()

--- a/src/prpy/collision.py
+++ b/src/prpy/collision.py
@@ -1,0 +1,65 @@
+# Copyright (c) 2013, Carnegie Mellon University
+# All rights reserved.
+# Authors: Chris Dellin <cdellin@gmail.com>
+#          Michael Koval <mkoval@cs.cmu.edu>
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions are met:
+#
+# - Redistributions of source code must retain the above copyright notice, this
+#   list of conditions and the following disclaimer.
+# - Redistributions in binary form must reproduce the above copyright notice,
+#   this list of conditions and the following disclaimer in the documentation
+#   and/or other materials provided with the distribution.
+# - Neither the name of Carnegie Mellon University nor the names of its
+#   contributors may be used to endorse or promote products derived from this
+#   software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+# AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+# ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE
+# LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR
+# CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF
+# SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS
+# INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN
+# CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE)
+# ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
+# POSSIBILITY OF SUCH DAMAGE.
+
+import openravepy
+from prpy.planning.exceptions import CollisionPlanningError
+from prpy.planning.exceptions import SelfCollisionPlanningError
+
+
+class SimpleRobotCollisionChecker:
+
+    def __init__(self, robot):
+        self.robot = robot
+        self.env = robot.GetEnv()
+
+    def CheckCollision(self):
+        report = openravepy.CollisionReport()
+        if self.env.CheckCollision(self.robot, report=report):
+            raise CollisionPlanningError.FromReport(report)
+        elif self.robot.CheckSelfCollision(report=report):
+            raise SelfCollisionPlanningError.FromReport(report)
+
+
+class BakedRobotCollisionChecker:
+
+    def __init__(self, robot):
+        self.robot = robot
+        self.env = robot.GetEnv()
+        self.checker = self.env.GetCollisionChecker()
+        kb_type = self.checker.SendCommand('BakeGetType')
+        self.checker.SendCommand('BakeBegin')
+        self.env.CheckCollision(self.robot)
+        self.robot.CheckSelfCollision()
+        self.baked = openravepy.RaveCreateKinBody(self.env, kb_type)
+        self.checker.SendCommand('BakeEnd')
+
+    def CheckCollision(self):
+        report = openravepy.CollisionReport()
+        if self.checker.CheckSelfCollision(self.baked, report):
+            raise CollisionPlanningError.FromReport(report)

--- a/src/prpy/collision.py
+++ b/src/prpy/collision.py
@@ -98,7 +98,7 @@ class BakedRobotCollisionChecker:
 
     def CheckCollision(self, report=None):
         # The baked check is performed by checking self collision on baked
-        return self.checker.CheckSelfCollision(self.baked, report):
+        return self.checker.CheckSelfCollision(self.baked, report)
 
     def VerifyCollisionFree(self):
         report = openravepy.CollisionReport()

--- a/src/prpy/collision.py
+++ b/src/prpy/collision.py
@@ -48,7 +48,14 @@ class SimpleRobotCollisionChecker:
         self.robot = robot
         self.env = robot.GetEnv()
 
-    def CheckCollision(self):
+    def CheckCollision(self, report=None):
+        if self.env.CheckCollision(self.robot, report=report):
+            return True
+        elif self.robot.CheckSelfCollision(report=report):
+            return True
+        return False
+
+    def VerifyCollisionFree(self):
         report = openravepy.CollisionReport()
         if self.env.CheckCollision(self.robot, report=report):
             raise CollisionPlanningError.FromReport(report)
@@ -89,8 +96,13 @@ class BakedRobotCollisionChecker:
         self.baked = openravepy.RaveCreateKinBody(self.env, kb_type)
         self.checker.SendCommand('BakeEnd')
 
-    def CheckCollision(self):
-        report = openravepy.CollisionReport()
+    def CheckCollision(self, report=None):
         # The baked check is performed by checking self collision on baked
         if self.checker.CheckSelfCollision(self.baked, report):
+            return True
+        return False
+
+    def VerifyCollisionFree(self):
+        report = openravepy.CollisionReport()
+        if self.CheckCollision(report=report):
             raise CollisionPlanningError.FromReport(report)

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -34,6 +34,7 @@ import logging
 import numpy
 import openravepy
 from ..util import SetTrajectoryTags, GetLinearCollisionCheckPts
+from ..collision import SimpleRobotCollisionChecker
 from .exceptions import (
     CollisionPlanningError,
     SelfCollisionPlanningError
@@ -166,9 +167,10 @@ class DistanceFieldManager(object):
 
 
 class CHOMPPlanner(BasePlanner):
-    def __init__(self, require_cache=False):
+    def __init__(self, require_cache=False, robot_collision_checker=SimpleRobotCollisionChecker):
         super(CHOMPPlanner, self).__init__()
         self.require_cache = require_cache
+        self.robot_collision_checker = robot_collision_checker
         self.setupEnv(self.env)
 
     def setupEnv(self, env):
@@ -274,14 +276,15 @@ class CHOMPPlanner(BasePlanner):
 
         with CollisionOptionsStateSaver(self.env.GetCollisionChecker(),
                                         CollisionOptions.ActiveDOFs):
+
+            # Instantiate a robot checker
+            robot_checker = self.robot_collision_checker(robot)
+
             for t, q in checks:
                 robot.SetActiveDOFValues(q)
 
-                report = openravepy.CollisionReport()
-                if self.env.CheckCollision(robot, report=report):
-                    raise CollisionPlanningError.FromReport(report)
-                elif robot.CheckSelfCollision(report=report):
-                    raise SelfCollisionPlanningError.FromReport(report)
+                # Check collision (throws an exception on collision)
+                robot_checker.CheckCollision()
 
         SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
 

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -284,7 +284,7 @@ class CHOMPPlanner(BasePlanner):
                 robot.SetActiveDOFValues(q)
 
                 # Check collision (throws an exception on collision)
-                robot_checker.CheckCollision()
+                robot_checker.VerifyCollisionFree()
 
         SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)
 

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -36,6 +36,7 @@ from prpy.planning.base import (
     ClonedPlanningMethod,
     Tags
 )
+from prpy.collision import SimpleRobotCollisionChecker
 from openravepy import CollisionOptions, CollisionOptionsStateSaver
 
 
@@ -52,8 +53,9 @@ class SnapPlanner(BasePlanner):
     most commonly used as the first item in a Sequence meta-planner to
     avoid calling a motion planner when the trivial solution is valid.
     """
-    def __init__(self):
+    def __init__(self, robot_collision_checker=SimpleRobotCollisionChecker):
         super(SnapPlanner, self).__init__()
+        self.robot_collision_checker = robot_collision_checker
 
     def __str__(self):
         return 'SnapPlanner'
@@ -176,18 +178,18 @@ class SnapPlanner(BasePlanner):
 
         with CollisionOptionsStateSaver(self.env.GetCollisionChecker(),
                                         CollisionOptions.ActiveDOFs):
+
+            # Instantiate a robot checker
+            robot_checker = self.robot_collision_checker(robot)
+
             # Run constraint checks at DOF resolution:
             for t, q in checks:
                 # Set the joint positions
                 # Note: the planner is using a cloned 'robot' object
                 robot.SetActiveDOFValues(q)
 
-                # Check for collisions
-                report = openravepy.CollisionReport()
-                if self.env.CheckCollision(robot, report=report):
-                    raise CollisionPlanningError.FromReport(report)
-                elif robot.CheckSelfCollision(report=report):
-                    raise SelfCollisionPlanningError.FromReport(report)
+                # Check collision (throws an exception on collision)
+                robot_checker.CheckCollision()
 
         # Tag the return trajectory as smooth (in joint space).
         SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -36,7 +36,7 @@ from prpy.planning.base import (
     ClonedPlanningMethod,
     Tags
 )
-from prpy.collision import SimpleRobotCollisionChecker
+from ..collision import SimpleRobotCollisionChecker
 from openravepy import CollisionOptions, CollisionOptionsStateSaver
 
 

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -189,7 +189,7 @@ class SnapPlanner(BasePlanner):
                 robot.SetActiveDOFValues(q)
 
                 # Check collision (throws an exception on collision)
-                robot_checker.CheckCollision()
+                robot_checker.VerifyCollisionFree()
 
         # Tag the return trajectory as smooth (in joint space).
         SetTrajectoryTags(traj, {Tags.SMOOTH: True}, append=True)

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -125,6 +125,11 @@ class TSRPlanner(BasePlanner):
                     'Cannot handle start or trajectory-wide TSR constraints.')
         tsrchains = [t for t in tsrchains if t.sample_goal]
 
+        # We assume the active manipulator's DOFs are active when computing IK,
+        # calling the delegate planners, and collision checking with the
+        # ActiveDOFs option set.
+        robot.SetActiveDOFs(manipulator.GetArmIndices())
+
         def compute_ik_solutions(tsrchain):
             pose = tsrchain.sample()
             ik_param = IkParameterization(pose,
@@ -158,11 +163,6 @@ class TSRPlanner(BasePlanner):
             'num_tsr_samples': 0,
             'num_ik_solutions': 0
         }
-
-        # We assume the active manipulator's DOFs are active when computing IK,
-        # calling the delegate planners, and collision checking with the
-        # ActiveDOFs option set.
-        robot.SetActiveDOFs(manipulator.GetArmIndices())
 
         configuration_generator = itertools.chain.from_iterable(
             itertools.ifilter(

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -35,7 +35,7 @@ import numpy
 import openravepy
 from .. import util
 from base import BasePlanner, PlanningError, ClonedPlanningMethod, Tags
-from prpy.collision import SimpleRobotCollisionChecker
+from ..collision import SimpleRobotCollisionChecker
 from enum import Enum
 from openravepy import CollisionOptions, CollisionOptionsStateSaver
 

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -504,7 +504,7 @@ class VectorFieldPlanner(BasePlanner):
                 robot.SetActiveDOFValues(q)
 
                 # Check collision (throws an exception on collision)
-                robot_checker.CheckCollision()
+                robot_checker.VerifyCollisionFree()
 
                 # Check the termination condition.
                 status = fn_terminate()

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -35,6 +35,7 @@ import numpy
 import openravepy
 from .. import util
 from base import BasePlanner, PlanningError, ClonedPlanningMethod, Tags
+from prpy.collision import SimpleRobotCollisionChecker
 from enum import Enum
 from openravepy import CollisionOptions, CollisionOptionsStateSaver
 
@@ -74,8 +75,9 @@ class Status(Enum):
 
 
 class VectorFieldPlanner(BasePlanner):
-    def __init__(self):
+    def __init__(self, robot_collision_checker=SimpleRobotCollisionChecker):
         super(VectorFieldPlanner, self).__init__()
+        self.robot_collision_checker = robot_collision_checker
 
     def __str__(self):
         return 'VectorFieldPlanner'
@@ -465,104 +467,104 @@ class VectorFieldPlanner(BasePlanner):
 
         time_start = time.time()
 
-        def fn_wrapper(t, q):
-            """
-            The integrator will try to solve this equation
-            at each time step.
-            Note: t is the integration time and is non-monotonic.
-            """
-            # Set the joint values, without checking the joint limits
-            robot.SetActiveDOFValues(q, CheckLimitsAction.Nothing)
-
-            return fn_vectorfield()
-
-        def fn_status_callback(t, q):
-            """
-            Check joint-limits and collisions for a specific joint
-            configuration. This is called multiple times at DOF
-            resolution in order to check along the entire length of the
-            trajectory.
-            Note: This is called by fn_callback, which is currently
-            called after each integration time step, which means we are
-            doing more checks than required.
-            """
-            if time.time() - time_start >= timelimit:
-                raise TimeLimitError()
-
-            # Check joint position limits.
-            # We do this before setting the joint angles.
-            util.CheckJointLimits(robot, q)
-
-            robot.SetActiveDOFValues(q)
-
-            # Check collision.
-            report = CollisionReport()
-            if env.CheckCollision(robot, report=report):
-                raise CollisionPlanningError.FromReport(report)
-            elif robot.CheckSelfCollision(report=report):
-                raise SelfCollisionPlanningError.FromReport(report)
-
-            # Check the termination condition.
-            status = fn_terminate()
-
-            if Status.DoesCache(status):
-                nonlocals['t_cache'] = t
-
-            if Status.DoesTerminate(status):
-                raise TerminationError()
-
-        def fn_callback(t, q):
-            """
-            This is called at every successful integration step.
-            """
-            try:
-                # Add the waypoint to the trajectory.
-                waypoint = numpy.zeros(cspec.GetDOF())
-                cspec.InsertDeltaTime(waypoint, t - path.GetDuration())
-                cspec.InsertJointValues(waypoint, q, robot, active_indices, 0)
-                path.Insert(path.GetNumWaypoints(), waypoint)
-
-                # Run constraint checks at DOF resolution.
-                if path.GetNumWaypoints() == 1:
-                    checks = [(t, q)]
-                else:
-                    # TODO: This should start at t_check. Unfortunately, a bug
-                    # in GetCollisionCheckPts causes this to enter an infinite
-                    # loop.
-                    checks = GetCollisionCheckPts(robot, path,
-                                                  include_start=False)
-                    # start_time=nonlocals['t_check'])
-
-                for t_check, q_check in checks:
-                    fn_status_callback(t_check, q_check)
-
-                    # Record the time of this check so we continue checking at
-                    # DOF resolution the next time the integrator takes a step.
-                    nonlocals['t_check'] = t_check
-
-                return 0  # Keep going.
-            except PlanningError as e:
-                nonlocals['exception'] = e
-                return -1  # Stop.
-
-        # Integrate the vector field to get a configuration space path.
-        #
-        # TODO: Tune the integrator parameters.
-        #
-        # Integrator: 'dopri5'
-        # DOPRI (Dormand & Prince 1980) is an explicit method for solving ODEs.
-        # It is a member of the Runge-Kutta family of solvers.
-        integrator = scipy.integrate.ode(f=fn_wrapper)
-        integrator.set_integrator(name='dopri5',
-                                  first_step=0.1,
-                                  atol=1e-3,
-                                  rtol=1e-3)
-        # Set function to be called at every successful integration step.
-        integrator.set_solout(fn_callback)
-        integrator.set_initial_value(y=robot.GetActiveDOFValues(), t=0.)
-
         with CollisionOptionsStateSaver(self.env.GetCollisionChecker(),
                                         CollisionOptions.ActiveDOFs):
+
+            # Instantiate a robot checker
+            robot_checker = self.robot_collision_checker(robot)
+
+            def fn_wrapper(t, q):
+                """
+                The integrator will try to solve this equation
+                at each time step.
+                Note: t is the integration time and is non-monotonic.
+                """
+                # Set the joint values, without checking the joint limits
+                robot.SetActiveDOFValues(q, CheckLimitsAction.Nothing)
+
+                return fn_vectorfield()
+
+            def fn_status_callback(t, q):
+                """
+                Check joint-limits and collisions for a specific joint
+                configuration. This is called multiple times at DOF
+                resolution in order to check along the entire length of the
+                trajectory.
+                Note: This is called by fn_callback, which is currently
+                called after each integration time step, which means we are
+                doing more checks than required.
+                """
+                if time.time() - time_start >= timelimit:
+                    raise TimeLimitError()
+
+                # Check joint position limits.
+                # We do this before setting the joint angles.
+                util.CheckJointLimits(robot, q)
+
+                robot.SetActiveDOFValues(q)
+
+                # Check collision (throws an exception on collision)
+                robot_checker.CheckCollision()
+
+                # Check the termination condition.
+                status = fn_terminate()
+
+                if Status.DoesCache(status):
+                    nonlocals['t_cache'] = t
+
+                if Status.DoesTerminate(status):
+                    raise TerminationError()
+
+            def fn_callback(t, q):
+                """
+                This is called at every successful integration step.
+                """
+                try:
+                    # Add the waypoint to the trajectory.
+                    waypoint = numpy.zeros(cspec.GetDOF())
+                    cspec.InsertDeltaTime(waypoint, t - path.GetDuration())
+                    cspec.InsertJointValues(waypoint, q, robot, active_indices, 0)
+                    path.Insert(path.GetNumWaypoints(), waypoint)
+
+                    # Run constraint checks at DOF resolution.
+                    if path.GetNumWaypoints() == 1:
+                        checks = [(t, q)]
+                    else:
+                        # TODO: This should start at t_check. Unfortunately, a bug
+                        # in GetCollisionCheckPts causes this to enter an infinite
+                        # loop.
+                        checks = GetCollisionCheckPts(robot, path,
+                                                      include_start=False)
+                        # start_time=nonlocals['t_check'])
+
+                    for t_check, q_check in checks:
+                        fn_status_callback(t_check, q_check)
+
+                        # Record the time of this check so we continue checking at
+                        # DOF resolution the next time the integrator takes a step.
+                        nonlocals['t_check'] = t_check
+
+                    return 0  # Keep going.
+                except PlanningError as e:
+                    nonlocals['exception'] = e
+                    return -1  # Stop.
+
+            # Integrate the vector field to get a configuration space path.
+            #
+            # TODO: Tune the integrator parameters.
+            #
+            # Integrator: 'dopri5'
+            # DOPRI (Dormand & Prince 1980) is an explicit method for solving ODEs.
+            # It is a member of the Runge-Kutta family of solvers.
+            integrator = scipy.integrate.ode(f=fn_wrapper)
+            integrator.set_integrator(name='dopri5',
+                                      first_step=0.1,
+                                      atol=1e-3,
+                                      rtol=1e-3)
+            # Set function to be called at every successful integration step.
+            integrator.set_solout(fn_callback)
+            integrator.set_initial_value(y=robot.GetActiveDOFValues(), t=0.)
+
             integrator.integrate(t=integration_time_interval)
 
         t_cache = nonlocals['t_cache']


### PR DESCRIPTION
In the push for baked checking in PrPy, this is a first pass which creates a two robot collision checkers:
- `SimpleRobotCollisionChecker`
- `BakedRobotCollisionChecker`
Each of these can be constructed for a robot, and expose a simple `CheckCollision` method, which raises a PrPy exception upon collision.

This PR also refactors the `SnapPlanner` and `VectorFieldPlanner` planners to make use of this abstraction.  The planners default to `SimpleRobotCollisionChecker`, but a different type can be passed in when they are instantiated, and this type will be used for its collision checking.

Note that the `BakedRobotCollisionChecker` is experimental, and only works with the `baked_checkers` branch of `or_fcl` at the moment.  Currently, the underlying checker does not expose which links provoked the collision, so the collision report is not helpful, and a vanilla `CollisionPlanningError` is currently thrown.

I'll wait to implement this for `TSRPlanner` until its PR (#322) is merged.