### PR TITLE
Enable CBiRRT L-2 norm for dof resolution

### DIFF
--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -198,6 +198,10 @@ class CBiRRTPlanner(BasePlanner):
 
         args = ['RunCBiRRT']
 
+        # By default, CBiRRT interprets the DOF resolutions as an
+        # L-infinity norm; this flag turns on the L-2 norm instead.
+        args += ['bdofresl2norm', '1']
+
         if extra_args is not None:
             args += extra_args
 

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -201,6 +201,7 @@ class CBiRRTPlanner(BasePlanner):
         # By default, CBiRRT interprets the DOF resolutions as an
         # L-infinity norm; this flag turns on the L-2 norm instead.
         args += ['bdofresl2norm', '1']
+        args += ['steplength', '0.05999']
 
         if extra_args is not None:
             args += extra_args


### PR DESCRIPTION
A recent [comps PR](https://github.com/personalrobotics/comps/pull/7) adds a flag (off by default) to switch CBiRRT's interpretation of the robot's DOF resolutions from an L-infinity norm to an L-2 norm.  Once that's merged, we should merge this to turn it on from PrPy (mirroring #332 for the Python planners).