### PR TITLE
Renamed collision checker context managers

### DIFF
--- a/src/prpy/collision.py
+++ b/src/prpy/collision.py
@@ -40,7 +40,7 @@ from prpy.planning.exceptions import (
 )
 
 
-class SimpleRobotCollisionCheckerContextManager(object):
+class SimpleRobotCollisionChecker(object):
     """RobotCollisionChecker which uses the standard OpenRAVE interface.
 
     This RobotCollisionChecker is instantiated with a robot,
@@ -88,7 +88,7 @@ class SimpleRobotCollisionCheckerContextManager(object):
             raise SelfCollisionPlanningError.FromReport(report)
 
 
-class BakedRobotCollisionCheckerContextManager(object):
+class BakedRobotCollisionChecker(object):
     """RobotCollisionChecker which uses a baked collision interface.
 
     When this RobotCollisionChecker is instantiated with a robot,
@@ -173,22 +173,20 @@ class BakedRobotCollisionCheckerContextManager(object):
             raise CollisionPlanningError.FromReport(report)
 
 
-class SimpleRobotCollisionChecker(object):
+class SimpleRobotCollisionCheckerFactory(object):
     def __init__(self, collision_options=CollisionOptions.ActiveDOFs):
         self.collision_options = collision_options
 
     def __call__(self, robot):
-        return SimpleRobotCollisionCheckerContextManager(
-            robot, self.collision_options)
+        return SimpleRobotCollisionChecker(robot, self.collision_options)
 
 
-class BakedRobotCollisionChecker(object):
+class BakedRobotCollisionCheckerFactory(object):
     def __init__(self, collision_options=CollisionOptions.ActiveDOFs):
         self.collision_options = collision_options
 
     def __call__(self, robot):
-        return BakedRobotCollisionCheckerContextManager(
-            robot, self.collision_options)
+        return BakedRobotCollisionChecker(robot, self.collision_options)
 
 
-DefaultRobotCollisionChecker = SimpleRobotCollisionChecker()
+DefaultRobotCollisionCheckerFactory = SimpleRobotCollisionCheckerFactory()

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -36,7 +36,7 @@ from prpy.planning.base import (
     ClonedPlanningMethod,
     Tags
 )
-from ..collision import DefaultRobotCollisionChecker
+from ..collision import DefaultRobotCollisionCheckerFactory
 
 
 class SnapPlanner(BasePlanner):
@@ -52,9 +52,13 @@ class SnapPlanner(BasePlanner):
     most commonly used as the first item in a Sequence meta-planner to
     avoid calling a motion planner when the trivial solution is valid.
     """
-    def __init__(self, robot_collision_checker=DefaultRobotCollisionChecker):
+    def __init__(self, robot_checker_factory=None):
         super(SnapPlanner, self).__init__()
-        self.robot_collision_checker = robot_collision_checker
+
+        if robot_checker_factory is None:
+            robot_checker_factory = DefaultRobotCollisionCheckerFactory
+
+        self.robot_checker_factory = robot_checker_factory
 
     def __str__(self):
         return 'SnapPlanner'
@@ -176,7 +180,7 @@ class SnapPlanner(BasePlanner):
                                             norm_order=2,
                                             sampling_func=vdc)
 
-        with self.robot_collision_checker(robot) as robot_checker:
+        with self.robot_checker_factory(robot) as robot_checker:
             # Run constraint checks at DOF resolution:
             for t, q in checks:
                 # Set the joint positions

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -36,7 +36,7 @@ from base import (BasePlanner, ClonedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
 from .base import Tags
 from ..util import SetTrajectoryTags
-from ..collision import DefaultRobotCollisionChecker
+from ..collision import DefaultRobotCollisionCheckerFactory
 from openravepy import (
     IkFilterOptions,
     IkParameterization,
@@ -58,10 +58,14 @@ def grouper(n, iterable):
 
 
 class TSRPlanner(BasePlanner):
-    def __init__(self, delegate_planner=None, robot_collision_checker=DefaultRobotCollisionChecker):
+    def __init__(self, delegate_planner=None, robot_checker_factory=None):
         super(TSRPlanner, self).__init__()
+
+        if robot_checker_factory is None:
+            robot_checker_factory = DefaultRobotCollisionCheckerFactory
+
         self.delegate_planner = delegate_planner
-        self.robot_collision_checker = robot_collision_checker
+        self.robot_checker_factory = robot_checker_factory
 
     def __str__(self):
         if self.delegate_planner is not None:
@@ -174,7 +178,7 @@ class TSRPlanner(BasePlanner):
             # Set ActiveDOFs for IK collision checking. We intentionally
             # restore the original collision checking options before calling
             # the planner to give it a pristine environment.
-            with self.robot_collision_checker(robot) as robot_checker:
+            with self.robot_checker_factory(robot) as robot_checker:
                 while is_time_available() and len(configurations_chunk) < chunk_size:
                     # Generate num_candidates candidates and rank them using the
                     # user-supplied IK ranker.

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -35,7 +35,7 @@ import numpy
 import openravepy
 from .base import BasePlanner, PlanningError, ClonedPlanningMethod, Tags
 from .. import util
-from ..collision import DefaultRobotCollisionChecker 
+from ..collision import DefaultRobotCollisionCheckerFactory
 from enum import Enum
 
 logger = logging.getLogger(__name__)
@@ -74,9 +74,13 @@ class Status(Enum):
 
 
 class VectorFieldPlanner(BasePlanner):
-    def __init__(self, robot_collision_checker=DefaultRobotCollisionChecker):
+    def __init__(self, robot_checker_factory=None):
         super(VectorFieldPlanner, self).__init__()
-        self.robot_collision_checker = robot_collision_checker
+
+        if robot_checker_factory is None:
+            robot_checker_factory = DefaultRobotCollisionCheckerFactory
+
+        self.robot_checker_factory = robot_checker_factory
 
     def __str__(self):
         return 'VectorFieldPlanner'
@@ -547,7 +551,7 @@ class VectorFieldPlanner(BasePlanner):
                 nonlocals['exception'] = e
                 return -1  # Stop.
 
-        with self.robot_collision_checker(robot) as robot_checker:
+        with self.robot_checker_factory(robot) as robot_checker:
             # Integrate the vector field to get a configuration space path.
             #
             # TODO: Tune the integrator parameters.


### PR DESCRIPTION
This addresses the naming issues introduced by #342. There is now a `xRobotCollisionCheckerFactory` that creates a `xRobotCollisionChecker`. We now use the names `robot_checker_factory` and `robot_checker`, respectively, to refer to instances of these classes.
