### PR TITLE
Don't depend on filename to determine robot name in tsrlibrary

### DIFF
--- a/src/prpy/tsr/tsrlibrary.py
+++ b/src/prpy/tsr/tsrlibrary.py
@@ -69,7 +69,7 @@ class TSRLibrary(object):
         if robot_name is not None:
             self.robot_name = robot_name
         else:
-            self.robot_name = self.get_object_type(robot)
+            self.robot_name = robot.GetName()
             logger.debug('Inferred robot name "%s" for TSRLibrary.', self.robot_name)
 
     def clone(self, cloned_robot):


### PR DESCRIPTION
Robots all implement `GetName()`, so we should use the names directly instead of inferring from a filename. I changed this to support models loaded via new personalrobotics/or_urdf method `LoadJsonString` https://github.com/personalrobotics/or_urdf/pull/26

@jeking04 @mkoval is there a reason not to do this?