### PR TITLE
fixed trajectory tags when using greedyik to plan to an end effector …

### DIFF
--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -79,7 +79,14 @@ class GreedyIKPlanner(BasePlanner):
                 maxaccelerations=0.1 * numpy.ones(7)
             )
 
-        return self.PlanWorkspacePath(robot, traj, timelimit)
+        qtraj = self.PlanWorkspacePath(robot, traj, timelimit)
+        # modify tags to reflect that we won't care about
+        # the entire path, but only the final pose
+        SetTrajectoryTags(qtraj, {
+            Tags.CONSTRAINED: False,
+            Tags.SMOOTH: True}, append=True)
+
+        return qtraj
 
     @ClonedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance,


### PR DESCRIPTION
Sets tags for greedyik so that if you plan to a pose, you do not model the path as constrained.