### PR TITLE
Added OMPLRangedPlanner class

### DIFF
--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -31,6 +31,7 @@
 import logging
 import numpy
 import openravepy
+import warnings
 from ..util import CopyTrajectory, SetTrajectoryTags
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
                   ClonedPlanningMethod, Tags)
@@ -163,10 +164,40 @@ class OMPLPlanner(BasePlanner):
         return traj
 
 
-class RRTConnect(OMPLPlanner):
-    def __init__(self):
-        OMPLPlanner.__init__(self, algorithm='RRTConnect')
+class OMPLRangedPlanner(OMPLPlanner):
+    """ Construct an OMPL planner with a default 'range' parameter set.
 
+    This class wraps OMPLPlanner by setting the default 'range' parameter,
+    which defines the length of an extension in algorithms like RRT-Connect, to
+    include an integer number 'multipler' of state validity checks.
+
+    @param algorithm name of the OMPL planner to create
+    @param robot_checker_factory robot collision checker factory
+    @param multiplier number of state validity checks per extension
+    """
+    def __init__(self, algorithm='RRTConnect', robot_checker_factory=None,
+            multiplier=1):
+        if multiplier < 1 or not isinstance(multiplier, int):
+            raise ValueError('Multiplier must be a positive integer.')
+
+        OMPLPlanner.__init__(self, algorithm='RRTConnect',
+                robot_checker_factory=robot_checker_factory)
+        self.multiplier = multiplier
+        self.epsilon = 1e-6
+
+
+    """ Set a default 'range' parameter from DOF resolutions.
+
+    This function returns a copy of the input 'ompl_args' argument with the
+    'range' parameter set to a default value, if it was not already set. The
+    default value is calculated from the active DOFs of 'robot such that there
+    will be an integer number of state validity checks per extension. That
+    multiplier is configured in the constructor of this class.
+
+    @param robot with active DOFs set
+    @param ompl_args arguments to append to, defaults to an empty dictionary
+    @return copy of ompl_args with 'range' set to the default value
+    """
     def _SetPlannerRange(self, robot, ompl_args=None):
         from copy import deepcopy
 
@@ -177,8 +208,6 @@ class RRTConnect(OMPLPlanner):
 
         # Set the default range to the collision checking resolution.
         if 'range' not in ompl_args:
-            epsilon = 1e-6
-
             # Compute the collision checking resolution as a conservative
             # fraction of the state space extents. This mimics the logic inside
             # or_ompl used to set collision checking resolution.
@@ -192,36 +221,32 @@ class RRTConnect(OMPLPlanner):
             # RRT-Connect's range to the same value used for collision
             # detection inside OpenRAVE.
             longest_extent = numpy.max(dof_ranges)
-            ompl_range = conservative_ratio * longest_extent - epsilon
+            ompl_range  = conservative_ratio * longest_extent - self.epsilon
+            ompl_range *= self.multiplier
 
             ompl_args['range'] = ompl_range
             logger.debug('Defaulted RRT-Connect range parameter to %.3f.',
                          ompl_range)
+
         return ompl_args
 
     @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, ompl_args=None, **kw_args):
-        """
-        Plan to a desired configuration with OMPL. This will invoke the OMPL
-        planner specified in the OMPLPlanner constructor.
-        @param robot
-        @param goal desired configuration
-        @return traj
-        """
         ompl_args = self._SetPlannerRange(robot, ompl_args=ompl_args)
         return self._Plan(robot, goal=goal, ompl_args=ompl_args, **kw_args)
 
     @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, ompl_args=None, **kw_args):
-        """
-        Plan using the given TSR chains with OMPL.
-        @param robot
-        @param tsrchains A list of TSRChain objects to respect during planning
-        @param ompl_args ompl RRTConnect specific parameters
-        @return traj
-        """
         ompl_args = self._SetPlannerRange(robot, ompl_args=ompl_args)
         return self._Plan(robot, tsrchains=tsrchains, ompl_args=ompl_args, **kw_args)
+
+
+# Alias to maintain backwards compatability.
+class RRTConnect(OMPLRangedPlanner):
+    def __init__(self):
+        super(RRTConnect, self).__init__(algorithm='RRTConnect')
+        warnings.warn('RRTConnect has been replaced by OMPLRangedPlanner.',
+                DeprecationWarning)
 
 
 class OMPLSimplifier(BasePlanner):

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -238,7 +238,7 @@ class OMPLRangedPlanner(OMPLPlanner):
         if self.multiplier is not None:
             multiplier = self.multiplier
         elif self.fraction is not None:
-            multiplier = numpy.ceil(self.fraction / conservative_fraction)
+            multiplier = max(round(self.fraction / conservative_fraction), 1)
         else:
             raise ValueError('Either multiplier or fraction must be set.')
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -223,7 +223,10 @@ class OMPLRangedPlanner(OMPLPlanner):
             axis_index = dof_index - joint.GetDOFIndex()
 
             if joint.IsCircular(axis_index):
-                dof_ranges[index] = 2 * numpy.pi
+                # There are 2*pi radians in a circular joint, but the maximum
+                # distance betwen any two points in SO(2) is pi. This is the
+                # definition used by OMPL.
+                dof_ranges[index] = numpy.pi
             else:
                 dof_ranges[index] = (dof_limit_upper[index]
                                    - dof_limit_lower[index])

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -239,7 +239,7 @@ class OMPLRangedPlanner(OMPLPlanner):
 
             # Duplicate the logic in or_ompl to convert the DOF resolutions to
             # a fraction of the longest extent of the state space.
-            maximum_extent = numpy.max(dof_ranges)
+            maximum_extent = numpy.linalg.norm(dof_ranges)
             dof_resolution = robot.GetActiveDOFResolutions()
             conservative_resolution = numpy.min(dof_resolution)
             conservative_fraction = conservative_resolution / maximum_extent
@@ -247,7 +247,7 @@ class OMPLRangedPlanner(OMPLPlanner):
             if self.multiplier is not None:
                 multiplier = self.multiplier
             elif self.fraction is not None:
-                multiplier = int(self.fraction / conservative_fraction + 0.5)
+                multiplier = numpy.ceil(self.fraction / conservative_fraction)
             else:
                 raise ValueError('Either multiplier or fraction must be set.')
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -33,6 +33,9 @@ import numpy
 import openravepy
 import warnings
 from ..util import CopyTrajectory, SetTrajectoryTags
+from copy import deepcopy
+from ..util import CopyTrajectory, SetTrajectoryTags, GetManipulatorIndex
+from ..tsr.tsr import TSR, TSRChain
 from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
                   ClonedPlanningMethod, Tags)
 from openravepy import (
@@ -169,7 +172,7 @@ class OMPLRangedPlanner(OMPLPlanner):
 
     This class wraps OMPLPlanner by setting the default 'range' parameter,
     which defines the length of an extension in algorithms like RRT-Connect, to
-    include an integer number 'multipler' of state validity checks.
+    include an fixed number 'multipler' of state validity checks.
 
     @param algorithm name of the OMPL planner to create
     @param robot_checker_factory robot collision checker factory
@@ -177,7 +180,7 @@ class OMPLRangedPlanner(OMPLPlanner):
     """
     def __init__(self, algorithm='RRTConnect', robot_checker_factory=None,
             multiplier=1):
-        if multiplier < 1 or not isinstance(multiplier, int):
+        if not (multiplier >= 1):
             raise ValueError('Multiplier must be a positive integer.')
 
         OMPLPlanner.__init__(self, algorithm='RRTConnect',
@@ -190,43 +193,45 @@ class OMPLRangedPlanner(OMPLPlanner):
 
     This function returns a copy of the input 'ompl_args' argument with the
     'range' parameter set to a default value, if it was not already set. The
-    default value is calculated from the active DOFs of 'robot such that there
-    will be an integer number of state validity checks per extension. That
-    multiplier is configured in the constructor of this class.
+    default value is calculated from the active DOFs of 'robot' such that there
+    will be an fixed number of state validity checks per extension. That number
+    is configured in the constructor of this class.
 
     @param robot with active DOFs set
     @param ompl_args arguments to append to, defaults to an empty dictionary
     @return copy of ompl_args with 'range' set to the default value
     """
     def _SetPlannerRange(self, robot, ompl_args=None):
-        from copy import deepcopy
-
         if ompl_args is None:
             ompl_args = dict()
         else:
             ompl_args = deepcopy(ompl_args)
 
-        # Set the default range to the collision checking resolution.
         if 'range' not in ompl_args:
-            # Compute the collision checking resolution as a conservative
-            # fraction of the state space extents. This mimics the logic inside
-            # or_ompl used to set collision checking resolution.
+            # Compute the maximum DOF range, treating circle joints as SO(2).
             dof_limit_lower, dof_limit_upper = robot.GetActiveDOFLimits()
-            dof_ranges = dof_limit_upper - dof_limit_lower
+            dof_ranges = numpy.zeros(robot.GetActiveDOF())
+
+            for index, dof_index in enumerate(robot.GetActiveDOFIndices()):
+                joint = robot.GetJointFromDOFIndex(dof_index)
+                axis_index = dof_index - joint.GetDOFIndex()
+
+                if joint.IsCircular(axis_index):
+                    dof_ranges[index] = 2 * numpy.pi
+                else:
+                    dof_ranges[index] = (dof_limit_upper[index]
+                                       - dof_limit_lower[index])
+
+            # Duplicate the logic in or_ompl to convert the DOF resolutions to
+            # a fraction of the longest extent of the state space. Then, scale
+            # this by the user-supplied multiple. Finally, subtract a small
+            # value to cope with numerical precision issues inside OMPL.
+            maximum_extent = numpy.max(dof_ranges)
             dof_resolution = robot.GetActiveDOFResolutions()
-            ratios = dof_resolution / dof_ranges
-            conservative_ratio = numpy.min(ratios)
-
-            # Convert the ratio back to a collision checking resolution. Set
-            # RRT-Connect's range to the same value used for collision
-            # detection inside OpenRAVE.
-            longest_extent = numpy.max(dof_ranges)
-            ompl_range  = conservative_ratio * longest_extent - self.epsilon
-            ompl_range *= self.multiplier
-
-            ompl_args['range'] = ompl_range
-            logger.debug('Defaulted RRT-Connect range parameter to %.3f.',
-                         ompl_range)
+            conservative_resolution = numpy.min(dof_resolution)
+            conservative_fraction = conservative_resolution / maximum_extent
+            ompl_args['range'] = (
+                    self.multiplier * conservative_fraction - self.epsilon)
 
         return ompl_args
 

--- a/tests/planning/test_OMPL.py
+++ b/tests/planning/test_OMPL.py
@@ -4,7 +4,7 @@ from methods import (
     PlanToConfigurationCompleteTest,
 )
 from planning_helpers import BasePlannerTest
-from prpy.planning.ompl import OMPLPlanner
+from prpy.planning.ompl import OMPLRangedPlanner
 from unittest import TestCase
 
 
@@ -13,4 +13,4 @@ class OMPLPlannerTests(BasePlannerTest,
                        PlanToConfigurationStraightLineTest,
                        PlanToConfigurationCompleteTest,
                        TestCase):
-    planner_factory = OMPLPlanner
+    planner_factory = OMPLRangedPlanner

--- a/tests/planning/test_OMPL.py
+++ b/tests/planning/test_OMPL.py
@@ -13,4 +13,4 @@ class OMPLPlannerTests(BasePlannerTest,
                        PlanToConfigurationStraightLineTest,
                        PlanToConfigurationCompleteTest,
                        TestCase):
-    planner_factory = OMPLRangedPlanner
+    planner_factory = lambda _: OMPLRangedPlanner(fraction=0.2)


### PR DESCRIPTION
This class adds logic for setting a 'range' parameter such that an
integer number of state validity checks will occur per extension. It
improves on the previous RRTConnect class in two ways:

1. Accepts an optional 'algorithm' parameter, e.g. for PR_RRTConnect.
2. Allows for more than one state validity checks per extension.

This also fixes #350.