### PR TITLE
Cleaned up OMPLPlanner

### DIFF
--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -243,8 +243,9 @@ class OMPLRangedPlanner(OMPLPlanner):
     @param fraction approximate fraction of the maximum extent of the state
                     space per extension
     """
-    def __init__(self, multiplier=None, fraction=None,
-                 algorithm='RRTConnect', robot_checker_factory=None):
+    def __init__(self, multiplier=None, fraction=None, **kwargs):
+        OMPLPlanner.__init__(self, **kwargs)
+
         if multiplier is None and fraction is None:
             raise ValueError('Either "multiplier" of "fraction" is required.')
         if multiplier is not None and fraction is not None:
@@ -253,9 +254,6 @@ class OMPLRangedPlanner(OMPLPlanner):
             raise ValueError('"mutiplier" must be a positive integer.')
         if fraction is not None and not (0. <= fraction <= 1.):
             raise ValueError('"fraction" must be between zero and one.')
-
-        OMPLPlanner.__init__(self, algorithm='RRTConnect',
-                robot_checker_factory=robot_checker_factory)
 
         self.multiplier = multiplier
         self.fraction = fraction
@@ -329,8 +327,9 @@ class OMPLRangedPlanner(OMPLPlanner):
 
 # Alias to maintain backwards compatability.
 class RRTConnect(OMPLRangedPlanner):
-    def __init__(self):
-        super(RRTConnect, self).__init__(algorithm='RRTConnect', fraction=0.2)
+    def __init__(self, **kwargs):
+        super(RRTConnect, self).__init__(
+              algorithm='RRTConnect', fraction=0.2, **kwargs)
         warnings.warn('RRTConnect has been replaced by OMPLRangedPlanner.',
                 DeprecationWarning)
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -32,28 +32,56 @@ import logging
 import numpy
 import openravepy
 import warnings
-from ..util import CopyTrajectory, SetTrajectoryTags
 from copy import deepcopy
-from ..util import CopyTrajectory, SetTrajectoryTags, GetManipulatorIndex
-from ..tsr.tsr import TSR, TSRChain
-from base import (BasePlanner, PlanningError, UnsupportedPlanningError,
-                  ClonedPlanningMethod, Tags)
 from openravepy import (
     CollisionOptionsStateSaver,
     PlannerStatus,
+    RaveCreatePlanner,
+    RaveCreateTrajectory,
 )
 from ..collision import (
     BakedRobotCollisionCheckerFactory,
     DefaultRobotCollisionCheckerFactory,
     SimpleRobotCollisionCheckerFactory,
 )
+from ..util import (
+    CopyTrajectory,
+    SetTrajectoryTags,
+    GetManipulatorIndex,
+)
+from ..tsr.tsr import (
+    TSR,
+    TSRChain,
+)
+from .base import (
+    BasePlanner,
+    ClonedPlanningMethod,
+    PlanningError,
+    Tags,
+    UnsupportedPlanningError,
+)
 from .cbirrt import SerializeTSRChain
+
 
 logger = logging.getLogger(__name__)
 
 
 class OMPLPlanner(BasePlanner):
-    def __init__(self, algorithm='RRTConnect', robot_checker_factory=None):
+    """ An OMPL planner exposed by or_ompl.
+
+    This class makes an OMPL planner, exposed by or_ompl, comport to the PrPy
+    BasePlanner interface. Default values for planner-specific parameters may
+    be provided in the 'ompl_args' dictionary. These values are overriden by
+    any passed into a planning method.
+
+
+    @param algorithm name of a planner exposed by or_ompl
+    @param robot_checker_factory either Simple or BakedCollisionCheckerFactory
+    @param timelimit default planning timelimit, in seconds
+    @param ompl_args dictionary of planner-specific arguments 
+    """
+    def __init__(self, algorithm='RRTConnect', robot_checker_factory=None,
+                 timelimit=5., ompl_args=None):
         super(OMPLPlanner, self).__init__()
 
         if robot_checker_factory is None:
@@ -61,12 +89,15 @@ class OMPLPlanner(BasePlanner):
 
         self.setup = False
         self.algorithm = algorithm
-
+        self.default_timelimit = timelimit
+        self.default_ompl_args = ompl_args if ompl_args is not None else dict()
         self.robot_checker_factory = robot_checker_factory
 
-        if isinstance(robot_checker_factory, SimpleRobotCollisionCheckerFactory):
+        if isinstance(robot_checker_factory,
+                SimpleRobotCollisionCheckerFactory):
             self._is_baked = False
-        elif isinstance(robot_checker_factory, BakedRobotCollisionCheckerFactory):
+        elif isinstance(robot_checker_factory,
+                BakedRobotCollisionCheckerFactory):
             self._is_baked = True
         else:
             raise NotImplementedError(
@@ -74,7 +105,7 @@ class OMPLPlanner(BasePlanner):
                 ' BakedRobotCollisionCheckerFactory.')
 
         planner_name = 'OMPL_{:s}'.format(algorithm)
-        self.planner = openravepy.RaveCreatePlanner(self.env, planner_name)
+        self.planner = RaveCreatePlanner(self.env, planner_name)
 
         if self.planner is None:
             raise UnsupportedPlanningError(
@@ -82,15 +113,17 @@ class OMPLPlanner(BasePlanner):
                 .format(planner_name))
 
     def __str__(self):
-        return 'OMPL {0:s}'.format(self.algorithm)
+        return 'OMPL_{0:s}'.format(self.algorithm)
 
     @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
-        Plan to a desired configuration with OMPL. This will invoke the OMPL
-        planner specified in the OMPLPlanner constructor.
+        Plan to a configuration using the robot's active DOFs.
+
         @param robot
         @param goal desired configuration
+        @param timelimit planning timelimit, in seconds
+        @param ompl_args dictionary of planner-specific arguments
         @return traj
         """
         return self._Plan(robot, goal=goal, **kw_args)
@@ -98,63 +131,89 @@ class OMPLPlanner(BasePlanner):
     @ClonedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, **kw_args):
         """
-        Plan using the given set of TSR chains with OMPL.
+        Plan to one or more goal TSR chains using the robot's active DOFs. This
+        planner does not support start or constraint TSRs.
+
         @param robot
         @param tsrchains A list of tsrchains to use during planning
-        @param return traj
+        @param timelimit planning timelimit, in seconds
+        @param ompl_args dictionary of planner-specific arguments
+        @return traj
         """
         return self._Plan(robot, tsrchains=tsrchains, **kw_args)
 
-    def _Plan(self, robot, goal=None, tsrchains=None, timeout=30., shortcut_timeout=5.,
+    def _Plan(self, robot, goal=None, tsrchains=None, timelimit=None,
               continue_planner=False, ompl_args=None,
-              formatted_extra_params=None, **kw_args):
-        env = robot.GetEnv()
-        extraParams = '<time_limit>{:f}</time_limit>'.format(timeout)
+              formatted_extra_params=None, timeout=None, **kw_args):
+        extraParams = ''
 
-        if ompl_args is not None:
-            for key, value in ompl_args.iteritems():
-                extraParams += '<{k:s}>{v:s}</{k:s}>'.format(
-                    k=str(key), v=str(value))
+        # Handle the 'timelimit' parameter.
+        if timeout is not None:
+            warnings.warn('"timeout" has been replaced by "timelimit".',
+                    DeprecationWarning)
+            timelimit = timeout
 
+        if timelimit is None:
+            timelimit = self.default_timelimit
+
+        if timelimit <= 0.:
+            raise ValueError('"timelimit" must be positive.')
+
+        extraParams += '<time_limit>{:f}</time_limit>'.format(timelimit)
+
+        # Handle other parameters that get passed directly to OMPL.
+        if ompl_args is None:
+            ompl_args = dict()
+
+        merged_ompl_args = deepcopy(self.default_ompl_args)
+        merged_ompl_args.update(ompl_args)
+
+        for key, value in merged_ompl_args.iteritems():
+            extraParams += '<{k:s}>{v:s}</{k:s}>'.format(
+                k=str(key), v=str(value))
+
+        # Serialize TSRs into the space-delimited format used by CBiRRT.
         if tsrchains is not None:
             for chain in tsrchains:
                 if chain.constrain or chain.sample_start: 
-                    raise UnsupportedPlanningError('Only goal tsr is supported by OMPL.')
+                    raise UnsupportedPlanningError(
+                        'Only goal tsr is supported by OMPL.')
                     
                 extraParams += '<{k:s}>{v:s}</{k:s}>'.format(
                     k='tsr_chain', v=SerializeTSRChain(chain))
 
+        # Enable baked collision checking. This is handled natively.
+        if self._is_baked and merged_ompl_args.get('do_baked', True):
+            extraParams += '<do_baked>1</do_baked>'
+
+        # Serialize formatted values last, in case of any overrides.
         if formatted_extra_params is not None:
             extraParams += formatted_extra_params
 
-        if self._is_baked and (ompl_args is None or 'do_baked' not in ompl_args):
-            extraParams += '<do_baked>1</do_baked>'
-
+        # Setup the planning query.
         params = openravepy.Planner.PlannerParameters()
         params.SetRobotActiveJoints(robot)
         if goal is not None:
             params.SetGoalConfig(goal)
         params.SetExtraParameters(extraParams)
 
-        traj = openravepy.RaveCreateTrajectory(env, 'GenericTrajectory')
+        if (not continue_planner) or (not self.setup):
+            self.planner.InitPlan(robot, params)
+            self.setup = True
 
-        # Plan.
-        with env:
-            if (not continue_planner) or (not self.setup):
-                self.planner.InitPlan(robot, params)
-                self.setup = True
+        # Bypass the context manager since or_ompl does its own baking.
+        env = robot.GetEnv()
+        robot_checker = self.robot_checker_factory(robot)
+        options = robot_checker.collision_options
+        with CollisionOptionsStateSaver(env.GetCollisionChecker(), options):
+            traj = RaveCreateTrajectory(env, 'GenericTrajectory')
+            status = self.planner.PlanPath(traj, releasegil=True)
 
-            # Bypass the context manager since or_ompl does its own baking.
-            robot_checker = self.robot_checker_factory(robot)
-            options = robot_checker.collision_options
-            with CollisionOptionsStateSaver(env.GetCollisionChecker(), options):
-                status = self.planner.PlanPath(traj, releasegil=True)
-
-            if status not in [PlannerStatus.HasSolution,
-                              PlannerStatus.InterruptedWithSolution]:
-                raise PlanningError(
-                    'Planner returned with status {:s}.'.format(str(status)),
-                    deterministic=False)
+        if status not in [PlannerStatus.HasSolution,
+                          PlannerStatus.InterruptedWithSolution]:
+            raise PlanningError(
+                'Planner returned with status {:s}.'.format(str(status)),
+                deterministic=False)
 
         # Tag the trajectory as non-determistic since most OMPL planners are
         # randomized. Additionally tag the goal as non-deterministic if OMPL


### PR DESCRIPTION
This pull request:

- Cleans up imports in `ompl.py`
- Adds missing docstrings.
- Adds the ability to specify `timelimit` and `ompl_args` in the constructor.
- Replaces `timeout` with `timelimit` to match other PrPy planners.
- Fixes `**kwargs` forwarding in the `OMPLPlanner` wrappers.
- Fixed a bug where `algorithm` was being ignored in favor of the default.