### PR TITLE
Range is actually a distance, not a fraction

### DIFF
--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -247,7 +247,7 @@ class OMPLRangedPlanner(OMPLPlanner):
 
         # Then, scale this by the user-supplied multiple. Finally, subtract
         # a small value to cope with numerical precision issues inside OMPL.
-        return multiplier * conservative_fraction - epsilon
+        return multiplier * conservative_resolution - epsilon
 
     @ClonedPlanningMethod
     def PlanToConfiguration(self, robot, goal, ompl_args=None, **kw_args):

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -236,11 +236,11 @@ class OMPLRangedPlanner(OMPLPlanner):
         maximum_extent = numpy.linalg.norm(dof_ranges)
         dof_resolution = robot.GetActiveDOFResolutions()
         conservative_resolution = numpy.min(dof_resolution)
-        conservative_fraction = conservative_resolution / maximum_extent
 
         if self.multiplier is not None:
             multiplier = self.multiplier
         elif self.fraction is not None:
+            conservative_fraction = conservative_resolution / maximum_extent
             multiplier = max(round(self.fraction / conservative_fraction), 1)
         else:
             raise ValueError('Either multiplier or fraction must be set.')


### PR DESCRIPTION
This was my mistake -- I maintained yesterday that the `range` parameter is given as a fraction as the maximum extent in the space.  While that's how it's determined by default (via OMPL's [configurePlannerRange](http://ompl.kavrakilab.org/classompl_1_1tools_1_1SelfConfig.html#a65bff53ea4bc6f158342a856175ab9a6)), the parameter itself is actually a distance after all.  Fixing this gives the expected behavior (changing from -epsilon to +epsilon gives a step change in the number of checks needed).