### PR TITLE
AprilTags DetectObjects uses kw_args

### DIFF
--- a/src/prpy/perception/apriltags.py
+++ b/src/prpy/perception/apriltags.py
@@ -111,7 +111,7 @@ class ApriltagsModule(PerceptionModule):
                                           reference_link)
 
             logger.warn('Waiting to detect objects...')
-            return detector.Update()
+            return detector.Update(**kw_args)
         except Exception, e:
             logger.error('Detecton failed update: %s' % str(e))
             raise
@@ -121,6 +121,7 @@ class ApriltagsModule(PerceptionModule):
         """
         Overriden method for detection_frame
         """
+
         added_kinbodies, updated_kinbodies = self._DetectObjects(robot.GetEnv(), **kw_args)
         return added_kinbodies + updated_kinbodies
                                           


### PR DESCRIPTION
Equips `robot.DetectObjects()` to use a dict as `**kw_args`. Linked to the following PR for `KinbodyDetector` : https://github.com/personalrobotics/kinbody_detector/pull/7