### PR TITLE
Switched from ClonedPlanningMethod To LockedPlanningMethod

### DIFF
--- a/src/prpy/planning/adapters.py
+++ b/src/prpy/planning/adapters.py
@@ -1,7 +1,7 @@
 import numpy
 from openravepy import Environment
 from .base import (
-    ClonedPlanningMethod,
+    LockedPlanningMethod,
     Planner,
 )
 from ..kin import (
@@ -27,10 +27,8 @@ class PlanToEndEffectorOffsetTSRAdapter(Planner):
         super(PlanToEndEffectorOffsetTSRAdapter, self).__init__()
 
         self.delegate_planner = delegate_planner
-        self.env = Environment()
 
-
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance, **kwargs):
         """ Plan to a desired end-effector offset with fixed orientation.
 

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -103,7 +103,7 @@ class LockedPlanningMethod(object):
         self.func = func
 
     def __call__(self, instance, robot, *args, **kw_args):
-        with robot.GetEnv(), robot.CreateRobotStateSaver():
+        with robot.GetEnv():
             # Perform the actual planning operation.
             traj = self.func(instance, robot, *args, **kw_args)
 

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -38,6 +38,7 @@ from ..futures import defer
 from ..util import CopyTrajectory, GetTrajectoryTags, SetTrajectoryTags
 from .exceptions import (ClonedPlanningError, MetaPlanningError,
                          PlanningError, UnsupportedPlanningError)
+from contextlib import contextmanager
 
 logger = logging.getLogger(__name__)
 
@@ -464,3 +465,11 @@ class MethodMask(MetaPlanner):
             return plan_fn(*args, **kw_args)
         else:
             raise UnsupportedPlanningError()
+
+@contextmanager
+def save_dof_limits(robot):
+    upper, lower = robot.GetDOFLimits()
+    try:
+        yield
+    finally:
+        robot.SetDOFLimits(upper, lower)

--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -103,7 +103,7 @@ class LockedPlanningMethod(object):
         self.func = func
 
     def __call__(self, instance, robot, *args, **kw_args):
-        with robot.GetEnv():
+        with robot.GetEnv(), robot.CreateRobotStateSaver():
             # Perform the actual planning operation.
             traj = self.func(instance, robot, *args, **kw_args)
 

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -39,7 +39,7 @@ from ..tsr import TSR, TSRChain
 from ..util import SetTrajectoryTags
 from .adapters import PlanToEndEffectorOffsetTSRAdapter
 from .base import (
-    BasePlanner,
+    Planner,
     LockedPlanningMethod,
     PlanningError,
     Tags,
@@ -49,7 +49,7 @@ from .base import (
 import contextlib
 
 
-class CBiRRTPlanner(BasePlanner):
+class CBiRRTPlanner(Planner):
     def __init__(self, robot_checker_factory=None, timelimit=5.):
         super(CBiRRTPlanner, self).__init__()
 

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -290,7 +290,6 @@ class CBiRRTPlanner(BasePlanner):
             raise PlanningError('Unknown error: ' + response,
                 deterministic=False)
 
-
         # Construct the output trajectory.
         with open(traj_path, 'rb') as traj_file:
             traj_xml = traj_file.read()

--- a/src/prpy/planning/chomp.py
+++ b/src/prpy/planning/chomp.py
@@ -187,9 +187,10 @@ class CHOMPPlanner(BasePlanner):
         except ImportError:
             raise UnsupportedPlanningError(
                 'Unable to import "orcdchomp". Is or_cdchomp installed?')
-        except openravepy.openrave_exception as e:
+
+        if module is None:
             raise UnsupportedPlanningError(
-                'Failed loading "orcdchomp" module: ' + str(e))
+                'Failed loading "orcdchomp" module')
 
         if module is None:
             raise UnsupportedPlanningError(

--- a/src/prpy/planning/ik.py
+++ b/src/prpy/planning/ik.py
@@ -31,14 +31,14 @@ import logging
 import numpy
 import openravepy
 from .. import ik_ranking
-from base import (BasePlanner,
+from base import (Planner,
                   PlanningError,
                   LockedPlanningMethod)
 
 logger = logging.getLogger(__name__)
 
 
-class IKPlanner(BasePlanner):
+class IKPlanner(Planner):
     def __init__(self, delegate_planner=None):
         super(IKPlanner, self).__init__()
         self.delegate_planner = delegate_planner

--- a/src/prpy/planning/ik.py
+++ b/src/prpy/planning/ik.py
@@ -33,7 +33,7 @@ import openravepy
 from .. import ik_ranking
 from base import (BasePlanner,
                   PlanningError,
-                  ClonedPlanningMethod)
+                  LockedPlanningMethod)
 
 logger = logging.getLogger(__name__)
 
@@ -47,7 +47,7 @@ class IKPlanner(BasePlanner):
         return 'IKPlanner'
 
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToIK(self, robot, pose, **kwargs):
         """
         Plan to a desired end effector pose with IKPlanner.
@@ -61,7 +61,7 @@ class IKPlanner(BasePlanner):
         """
         return self._PlanToIK(robot, pose, **kwargs)
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToEndEffectorPose(self, robot, pose, **kwargs):
         """
         Plan to a desired end effector pose with IKPlanner.

--- a/src/prpy/planning/named.py
+++ b/src/prpy/planning/named.py
@@ -28,9 +28,9 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import logging, numpy, openravepy
-from base import BasePlanner, PlanningError, LockedPlanningMethod
+from base import Planner, PlanningError, LockedPlanningMethod
 
-class NamedPlanner(BasePlanner):
+class NamedPlanner(Planner):
     def __init__(self, delegate_planner=None):
         """
         @param delegate_planner planner used for PlanToConfiguration

--- a/src/prpy/planning/named.py
+++ b/src/prpy/planning/named.py
@@ -28,7 +28,7 @@
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 import logging, numpy, openravepy
-from base import BasePlanner, PlanningError, ClonedPlanningMethod
+from base import BasePlanner, PlanningError, LockedPlanningMethod
 
 class NamedPlanner(BasePlanner):
     def __init__(self, delegate_planner=None):
@@ -41,7 +41,7 @@ class NamedPlanner(BasePlanner):
     def __str__(self):
         return 'NamedPlanner'
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToNamedConfiguration(self, robot, name, **kw_args):
         """ Plan to a named configuration.
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -92,7 +92,6 @@ class OMPLPlanner(BasePlanner):
         if robot_checker_factory is None:
             robot_checker_factory = DefaultRobotCollisionCheckerFactory
 
-        self.setup = False
         self.algorithm = algorithm
         self.default_timelimit = timelimit
         self.default_ompl_args = ompl_args if ompl_args is not None else dict()
@@ -141,8 +140,8 @@ class OMPLPlanner(BasePlanner):
         return self._Plan(robot, tsrchains=tsrchains, **kw_args)
 
     def _Plan(self, robot, goal=None, tsrchains=None, timelimit=None,
-              continue_planner=False, ompl_args=None,
-              formatted_extra_params=None, timeout=None, **kw_args):
+              ompl_args=None, formatted_extra_params=None,
+              timeout=None, **kw_args):
         extraParams = ''
 
         # Handle the 'timelimit' parameter.
@@ -218,9 +217,7 @@ class OMPLPlanner(BasePlanner):
             params.SetGoalConfig(goal)
         params.SetExtraParameters(extraParams)
 
-        if (not continue_planner) or (not self.setup):
-            planner.InitPlan(robot, params)
-            setup = True
+        planner.InitPlan(robot, params)
 
         # Bypass the context manager since or_ompl does its own baking.
         env = robot.GetEnv()
@@ -376,7 +373,7 @@ class OMPLSimplifier(BasePlanner):
 
         if planner is None:
             raise UnsupportedPlanningError(
-                'Unable to create OMPL_Simplifier planner.')
+                'Unable to create {} planner.'.format(planner_name))
 
         output_path = CopyTrajectory(path, env=env)
 

--- a/src/prpy/planning/ompl.py
+++ b/src/prpy/planning/ompl.py
@@ -55,7 +55,7 @@ from ..tsr.tsr import (
     TSRChain,
 )
 from .base import (
-    BasePlanner,
+    Planner,
     LockedPlanningMethod,
     PlanningError,
     Tags,
@@ -67,7 +67,7 @@ from .cbirrt import SerializeTSRChain
 logger = logging.getLogger(__name__)
 
 
-class OMPLPlanner(BasePlanner):
+class OMPLPlanner(Planner):
     def __init__(self, algorithm='RRTConnect', robot_checker_factory=None,
                  timelimit=5., supports_constraints=False, ompl_args=None):
         """ An OMPL planner exposed by or_ompl.
@@ -355,7 +355,7 @@ class RRTConnect(OMPLRangedPlanner):
                 DeprecationWarning)
 
 
-class OMPLSimplifier(BasePlanner):
+class OMPLSimplifier(Planner):
     def __init__(self):
         super(OMPLSimplifier, self).__init__()
 

--- a/src/prpy/planning/openrave.py
+++ b/src/prpy/planning/openrave.py
@@ -35,7 +35,7 @@ import openravepy
 from base import (BasePlanner,
                   PlanningError,
                   UnsupportedPlanningError,
-                  ClonedPlanningMethod)
+                  LockedPlanningMethod)
 
 
 class OpenRAVEPlanner(BasePlanner):
@@ -45,16 +45,10 @@ class OpenRAVEPlanner(BasePlanner):
         self.setup = False
         self.algorithm = algorithm
 
-        try:
-            self.planner = openravepy.RaveCreatePlanner(self.env, algorithm)
-        except openravepy.openrave_exception:
-            raise UnsupportedPlanningError('Unable to create {:s} module.'
-                                           .format(str(self)))
-
     def __str__(self):
         return 'OpenRAVE {0:s}'.format(self.algorithm)
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Plan to a desired configuration with OpenRAVE. This will invoke the
@@ -68,6 +62,14 @@ class OpenRAVEPlanner(BasePlanner):
 
     def _Plan(self, robot, goals, maxiter=500, continue_planner=False,
               or_args=None, **kw_args):
+
+        env = robot.GetEnv()
+
+        try:
+            planner = openravepy.RaveCreatePlanner(env, algorithm)
+        except openravepy.openrave_exception:
+            raise UnsupportedPlanningError('Unable to create {:s} module.'
+                                           .format(str(self)))
 
         # Get rid of default postprocessing
         extraParams = ('<_postprocessing planner="">'
@@ -87,17 +89,17 @@ class OpenRAVEPlanner(BasePlanner):
         params.SetGoalConfig(goals)
         params.SetExtraParameters(extraParams)
 
-        traj = openravepy.RaveCreateTrajectory(self.env, 'GenericTrajectory')
+        traj = openravepy.RaveCreateTrajectory(env, 'GenericTrajectory')
 
         try:
-            self.env.Lock()
+            env.Lock()
 
             # Plan.
             if (not continue_planner) or not self.setup:
-                self.planner.InitPlan(robot, params)
+                planner.InitPlan(robot, params)
                 self.setup = True
 
-            status = self.planner.PlanPath(traj, releasegil=True)
+            status = planner.PlanPath(traj, releasegil=True)
             from openravepy import PlannerStatus
             if status not in [PlannerStatus.HasSolution,
                               PlannerStatus.InterruptedWithSolution]:
@@ -106,7 +108,7 @@ class OpenRAVEPlanner(BasePlanner):
         except Exception as e:
             raise PlanningError('Planning failed with error: {:s}'.format(e))
         finally:
-            self.env.Unlock()
+            env.Unlock()
 
         return traj
 
@@ -116,7 +118,7 @@ class BiRRTPlanner(OpenRAVEPlanner):
     def __init__(self):
         OpenRAVEPlanner.__init__(self, algorithm='birrt')
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Plan to a desired configuration with OpenRAVE. This will invoke the
@@ -127,7 +129,7 @@ class BiRRTPlanner(OpenRAVEPlanner):
         """
         return self._Plan(robot, goal, **kw_args)
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToConfigurations(self, robot, goals, **kw_args):
         """
         Plan to one of many configuration with OpenRAVE's BiRRT planner.

--- a/src/prpy/planning/openrave.py
+++ b/src/prpy/planning/openrave.py
@@ -94,17 +94,18 @@ class OpenRAVEPlanner(BasePlanner):
         try:
             env.Lock()
 
-            # Plan.
-            if (not continue_planner) or not self.setup:
-                planner.InitPlan(robot, params)
-                self.setup = True
+            with robot.CreateRobotStateSaver(Robot.SaveParameters.LinkTransformation):
+                # Plan.
+                if (not continue_planner) or not self.setup:
+                    planner.InitPlan(robot, params)
+                    self.setup = True
 
-            status = planner.PlanPath(traj, releasegil=True)
-            from openravepy import PlannerStatus
-            if status not in [PlannerStatus.HasSolution,
-                              PlannerStatus.InterruptedWithSolution]:
-                raise PlanningError('Planner returned with status {:s}.'
-                                    .format(str(status)))
+                status = planner.PlanPath(traj, releasegil=True)
+                from openravepy import PlannerStatus
+                if status not in [PlannerStatus.HasSolution,
+                                  PlannerStatus.InterruptedWithSolution]:
+                    raise PlanningError('Planner returned with status {:s}.'
+                                        .format(str(status)))
         except Exception as e:
             raise PlanningError('Planning failed with error: {:s}'.format(e))
         finally:

--- a/src/prpy/planning/openrave.py
+++ b/src/prpy/planning/openrave.py
@@ -65,9 +65,8 @@ class OpenRAVEPlanner(BasePlanner):
 
         env = robot.GetEnv()
 
-        try:
-            planner = openravepy.RaveCreatePlanner(env, algorithm)
-        except openravepy.openrave_exception:
+        planner = openravepy.RaveCreatePlanner(env, self.algorithm)
+        if planner is None:
             raise UnsupportedPlanningError('Unable to create {:s} module.'
                                            .format(str(self)))
 
@@ -94,7 +93,8 @@ class OpenRAVEPlanner(BasePlanner):
         try:
             env.Lock()
 
-            with robot.CreateRobotStateSaver(Robot.SaveParameters.LinkTransformation):
+            with robot.CreateRobotStateSaver(
+                openravepy.Robot.SaveParameters.LinkTransformation):
                 # Plan.
                 if (not continue_planner) or not self.setup:
                     planner.InitPlan(robot, params)

--- a/src/prpy/planning/openrave.py
+++ b/src/prpy/planning/openrave.py
@@ -32,13 +32,13 @@
 
 import numpy
 import openravepy
-from base import (BasePlanner,
+from base import (Planner,
                   PlanningError,
                   UnsupportedPlanningError,
                   LockedPlanningMethod)
 
 
-class OpenRAVEPlanner(BasePlanner):
+class OpenRAVEPlanner(Planner):
     def __init__(self, algorithm='birrt'):
         super(OpenRAVEPlanner, self).__init__()
 

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -33,14 +33,14 @@ import openravepy
 from copy import deepcopy
 from ..util import (CreatePlannerParametersString, CopyTrajectory,
                     SimplifyTrajectory, HasAffineDOFs, IsTimedTrajectory)
-from base import (BasePlanner, PlanningError, LockedPlanningMethod,
+from .base import (Planner, PlanningError, LockedPlanningMethod,
                   UnsupportedPlanningError)
-from openravepy import PlannerStatus, Planner, Robot
+from openravepy import PlannerStatus, Robot
 
 logger = logging.getLogger(__name__)
 
 
-class OpenRAVERetimer(BasePlanner):
+class OpenRAVERetimer(Planner):
     def __init__(self, algorithm, default_options=None):
         super(OpenRAVERetimer, self).__init__()
 
@@ -76,7 +76,7 @@ class OpenRAVERetimer(BasePlanner):
             all_options.update(options)
 
         env = robot.GetEnv()
-        params = Planner.PlannerParameters()
+        params = openravepy.Planner.PlannerParameters()
         params.SetConfigurationSpecification(
             env, cspec.GetTimeDerivativeSpecification(0))
 
@@ -161,7 +161,7 @@ class HauserParabolicSmoother(OpenRAVERetimer):
         return super(HauserParabolicSmoother, self).RetimeTrajectory(
             robot, path, options=new_options, **kw_args)
 
-class OpenRAVEAffineRetimer(BasePlanner):
+class OpenRAVEAffineRetimer(Planner):
     def __init__(self,):
         super(OpenRAVEAffineRetimer, self).__init__()
 
@@ -209,7 +209,7 @@ class OpenRAVEAffineRetimer(BasePlanner):
         return output_traj
 
 
-class OptimizingPlannerSmoother(BasePlanner):
+class OptimizingPlannerSmoother(Planner):
 
     def __init__(self, optimizing_planner, **kwargs):
         super(OptimizingPlannerSmoother, self).__init__()

--- a/src/prpy/planning/retimer.py
+++ b/src/prpy/planning/retimer.py
@@ -33,32 +33,24 @@ import openravepy
 from copy import deepcopy
 from ..util import (CreatePlannerParametersString, CopyTrajectory,
                     SimplifyTrajectory, HasAffineDOFs, IsTimedTrajectory)
-from base import (BasePlanner, PlanningError, ClonedPlanningMethod,
+from base import (BasePlanner, PlanningError, LockedPlanningMethod,
                   UnsupportedPlanningError)
-from openravepy import PlannerStatus, Planner
+from openravepy import PlannerStatus, Planner, Robot
 
 logger = logging.getLogger(__name__)
 
 
 class OpenRAVERetimer(BasePlanner):
     def __init__(self, algorithm, default_options=None):
-        from .base import UnsupportedPlanningError
-        from openravepy import RaveCreatePlanner
-
         super(OpenRAVERetimer, self).__init__()
 
         self.algorithm = algorithm
         self.default_options = default_options or dict()
 
-        self.planner = RaveCreatePlanner(self.env, algorithm)
-        if self.planner is None:
-            raise UnsupportedPlanningError(
-                'Unable to create "{:s}" planner.'.format(algorithm))
-
     def __str__(self):
         return self.algorithm
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kw_args):
         from openravepy import CollisionOptions, CollisionOptionsStateSaver
         from copy import deepcopy
@@ -83,32 +75,38 @@ class OpenRAVERetimer(BasePlanner):
         if options is not None:
             all_options.update(options)
 
+        env = robot.GetEnv()
         params = Planner.PlannerParameters()
         params.SetConfigurationSpecification(
-            self.env, cspec.GetTimeDerivativeSpecification(0))
+            env, cspec.GetTimeDerivativeSpecification(0))
 
         params_str = CreatePlannerParametersString(all_options, params)
 
         # Copy the input trajectory into the planning environment. This is
         # necessary for two reasons: (1) the input trajectory may be in another
         # environment and/or (2) the retimer modifies the trajectory in-place.
-        output_traj = CopyTrajectory(path, env=self.env)
+        output_traj = CopyTrajectory(path, env=env)
 
         # Remove co-linear waypoints. Some of the default OpenRAVE retimers do
         # not perform this check internally (e.g. ParabolicTrajectoryRetimer).
         if not IsTimedTrajectory(output_traj):
             output_traj = SimplifyTrajectory(output_traj, robot)
 
-        # Only collision check the active DOFs.
-        dof_indices, _ = cspec.ExtractUsedIndices(robot)
-        robot.SetActiveDOFs(dof_indices)
+        with robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOF), \
+            CollisionOptionsStateSaver(env.GetCollisionChecker(),
+                                       CollisionOptions.ActiveDOFs):
+            # Only collision check the active DOFs.
+            dof_indices, _ = cspec.ExtractUsedIndices(robot)
+            robot.SetActiveDOFs(dof_indices)
 
-        # Compute the timing. This happens in-place.
-        self.planner.InitPlan(None, params_str)
+            # Compute the timing. This happens in-place.
+            planner = openravepy.RaveCreatePlanner(env, self.algorithm)
+            if planner is None:
+                raise UnsupportedPlanningError(
+                    'Unable to create "{:s}" planner.'.format(self.algorithm))
+            planner.InitPlan(None, params_str)
 
-        with CollisionOptionsStateSaver(self.env.GetCollisionChecker(),
-                                        CollisionOptions.ActiveDOFs):
-            status = self.planner.PlanPath(output_traj, releasegil=True)
+            status = planner.PlanPath(output_traj, releasegil=True)
 
         if status not in [PlannerStatus.HasSolution,
                           PlannerStatus.InterruptedWithSolution]:
@@ -155,7 +153,7 @@ class HauserParabolicSmoother(OpenRAVERetimer):
             'time_limit': float(timelimit),
         })
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kw_args):
         new_options = deepcopy(options) if options else dict()
         if 'timelimit' in kw_args:
@@ -167,7 +165,7 @@ class OpenRAVEAffineRetimer(BasePlanner):
     def __init__(self,):
         super(OpenRAVEAffineRetimer, self).__init__()
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def RetimeTrajectory(self, robot, path, **kw_args):
 
         RetimeTrajectory = openravepy.planningutils.RetimeAffineTrajectory
@@ -193,7 +191,7 @@ class OpenRAVEAffineRetimer(BasePlanner):
         # Copy the input trajectory into the planning environment. This is
         # necessary for two reasons: (1) the input trajectory may be in another
         # environment and/or (2) the retimer modifies the trajectory in-place.
-        output_traj = CopyTrajectory(path, env=self.env)
+        output_traj = CopyTrajectory(path, env=env)
 
         # Compute the timing. This happens in-place.
         max_velocities = [robot.GetAffineTranslationMaxVels()[0],
@@ -221,7 +219,7 @@ class OptimizingPlannerSmoother(BasePlanner):
     def __str__(self):
         return 'OptimizingPlannerSmoother({})'.format(str(self.planner))
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def RetimeTrajectory(self, robot, path, options=None, **kwargs):
         logger.warning(
             'OptimizingPlannerSmoother is very experimental!')

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -34,7 +34,7 @@ from prpy.util import SetTrajectoryTags
 from prpy.planning.base import (
     BasePlanner,
     PlanningError,
-    ClonedPlanningMethod,
+    LockedPlanningMethod,
     Tags
 )
 from ..collision import DefaultRobotCollisionCheckerFactory
@@ -64,7 +64,7 @@ class SnapPlanner(BasePlanner):
     def __str__(self):
         return 'SnapPlanner'
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToConfiguration(self, robot, goal, **kw_args):
         """
         Attempt to plan a straight line trajectory from the robot's

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -131,8 +131,7 @@ class SnapPlanner(BasePlanner):
                                             sampling_func=vdc)
 
         with self.robot_checker_factory(robot) as robot_checker, \
-        robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOF | 
-                                Robot.SaveParameters.LinkTransformation):
+        robot.CreateRobotStateSaver(Robot.SaveParameters.LinkTransformation):
             # Run constraint checks at DOF resolution:
             for t, q in checks:
                 # Set the joint positions

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -32,7 +32,7 @@ import openravepy
 from openravepy import Robot
 from prpy.util import SetTrajectoryTags
 from prpy.planning.base import (
-    BasePlanner,
+    Planner,
     PlanningError,
     LockedPlanningMethod,
     Tags
@@ -40,7 +40,7 @@ from prpy.planning.base import (
 from ..collision import DefaultRobotCollisionCheckerFactory
 
 
-class SnapPlanner(BasePlanner):
+class SnapPlanner(Planner):
     """Planner that checks the straight-line trajectory to the goal.
 
     SnapPlanner is a utility planner class that collision checks the

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -131,7 +131,7 @@ class SnapPlanner(BasePlanner):
                                             sampling_func=vdc)
 
         with self.robot_checker_factory(robot) as robot_checker, \
-        robot.CreateRobotStateSaver(Robot.SaveParameters.LinkTransformation):
+            robot.CreateRobotStateSaver(Robot.SaveParameters.LinkTransformation):
             # Run constraint checks at DOF resolution:
             for t, q in checks:
                 # Set the joint positions

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -29,6 +29,7 @@
 # POSSIBILITY OF SUCH DAMAGE.
 import numpy
 import openravepy
+from openravepy import Robot
 from prpy.util import SetTrajectoryTags
 from prpy.planning.base import (
     BasePlanner,
@@ -85,7 +86,8 @@ class SnapPlanner(BasePlanner):
         # Create a two-point trajectory between the
         # current configuration and the goal.
         # (a straight line in joint space)
-        traj = openravepy.RaveCreateTrajectory(self.env, '')
+        env = robot.GetEnv()
+        traj = openravepy.RaveCreateTrajectory(env, '')
         cspec = robot.GetActiveConfigurationSpecification('linear')
         active_indices = robot.GetActiveDOFIndices()
 
@@ -128,7 +130,9 @@ class SnapPlanner(BasePlanner):
                                             norm_order=2,
                                             sampling_func=vdc)
 
-        with self.robot_checker_factory(robot) as robot_checker:
+        with self.robot_checker_factory(robot) as robot_checker, \
+        robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOF | 
+                                Robot.SaveParameters.LinkTransformation):
             # Run constraint checks at DOF resolution:
             for t, q in checks:
                 # Set the joint positions

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -163,7 +163,7 @@ class TSRPlanner(BasePlanner):
             # restore the original collision checking options before calling
             # the planner to give it a pristine environment.
             with self.robot_checker_factory(robot) as robot_checker, \
-                robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOFs, \
+                robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOF |
                                 Robot.SaveParameters.LinkTransformation):
 
                 # We assume the active manipulator's DOFs are active when computing IK,

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -74,18 +74,6 @@ class TSRPlanner(BasePlanner):
         else:
             return 'TSRPlanner'
 
-    # TODO: Temporarily disabled based on Pras' feedback.
-    """
-    @LockedPlanningMethod
-    def PlanToIK(self, robot, goal_pose, **kw_args):
-        from ..tsr import TSR, TSRChain
-
-        tsr = TSR(T0_w=goal_pose, Tw_e=numpy.eye(4), Bw=numpy.zeros((6,2)))
-        tsr_chain = TSRChain(sample_goal=True, TSR=tsr)
-
-        return self.PlanToTSR(robot, [tsr_chain], **kw_args)
-    """
-
     @LockedPlanningMethod
     def PlanToTSR(self, robot, tsrchains, tsr_timeout=0.5,
                   num_attempts=3, chunk_size=1, num_candidates=50, ranker=None,

--- a/src/prpy/planning/tsr.py
+++ b/src/prpy/planning/tsr.py
@@ -32,7 +32,7 @@ import time
 import itertools
 import numpy
 import openravepy
-from base import (BasePlanner, LockedPlanningMethod, PlanningError,
+from base import (Planner, LockedPlanningMethod, PlanningError,
                   UnsupportedPlanningError)
 from .base import Tags
 from ..util import SetTrajectoryTags
@@ -58,7 +58,7 @@ def grouper(n, iterable):
 
 
 
-class TSRPlanner(BasePlanner):
+class TSRPlanner(Planner):
     def __init__(self, delegate_planner=None, robot_checker_factory=None):
         super(TSRPlanner, self).__init__()
 

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -560,8 +560,7 @@ class VectorFieldPlanner(BasePlanner):
                 return -1  # Stop.
 
         with self.robot_checker_factory(robot) as robot_checker, \
-            robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOF |
-                            Robot.SaveParameters.LinkTransformation):
+            robot.CreateRobotStateSaver(Robot.SaveParameters.LinkTransformation):
             # Integrate the vector field to get a configuration space path.
             #
             # TODO: Tune the integrator parameters.

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -33,10 +33,11 @@
 import logging
 import numpy
 import openravepy
-from .base import BasePlanner, PlanningError, ClonedPlanningMethod, Tags
+from .base import BasePlanner, PlanningError, LockedPlanningMethod, Tags
 from .. import util
 from ..collision import DefaultRobotCollisionCheckerFactory
 from enum import Enum
+from openravepy import Robot
 
 logger = logging.getLogger(__name__)
 
@@ -85,7 +86,7 @@ class VectorFieldPlanner(BasePlanner):
     def __str__(self):
         return 'VectorFieldPlanner'
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToEndEffectorPose(self, robot, goal_pose, timelimit=5.0,
                               pose_error_tol=0.01,
                               integration_interval=10.0,
@@ -142,7 +143,7 @@ class VectorFieldPlanner(BasePlanner):
         util.SetTrajectoryTags(traj, {Tags.CONSTRAINED: False}, append=True)
         return traj
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanToEndEffectorOffset(self, robot, direction, distance,
                                 max_distance=None, timelimit=5.0,
                                 position_tolerance=0.01,
@@ -234,7 +235,7 @@ class VectorFieldPlanner(BasePlanner):
                                       integration_interval, timelimit,
                                       **kw_args)
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def PlanWorkspacePath(self, robot, traj,
                           timelimit=5.0,
                           position_tolerance=0.01,
@@ -422,7 +423,7 @@ class VectorFieldPlanner(BasePlanner):
                                       integration_interval,
                                       timelimit, **kw_args)
 
-    @ClonedPlanningMethod
+    @LockedPlanningMethod
     def FollowVectorField(self, robot, fn_vectorfield, fn_terminate,
                           integration_time_interval=10.0, timelimit=5.0,
                           sampling_func=util.SampleTimeGenerator,
@@ -558,7 +559,9 @@ class VectorFieldPlanner(BasePlanner):
                 nonlocals['exception'] = e
                 return -1  # Stop.
 
-        with self.robot_checker_factory(robot) as robot_checker:
+        with self.robot_checker_factory(robot) as robot_checker, \
+            robot.CreateRobotStateSaver(Robot.SaveParameters.ActiveDOF |
+                            Robot.SaveParameters.LinkTransformation):
             # Integrate the vector field to get a configuration space path.
             #
             # TODO: Tune the integrator parameters.

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -33,7 +33,7 @@
 import logging
 import numpy
 import openravepy
-from .base import BasePlanner, PlanningError, LockedPlanningMethod, Tags
+from .base import Planner, PlanningError, LockedPlanningMethod, Tags
 from .. import util
 from ..collision import DefaultRobotCollisionCheckerFactory
 from enum import Enum
@@ -74,7 +74,7 @@ class Status(Enum):
         return status in [cls.CACHE_AND_CONTINUE, cls.CACHE_AND_TERMINATE]
 
 
-class VectorFieldPlanner(BasePlanner):
+class VectorFieldPlanner(Planner):
     def __init__(self, robot_checker_factory=None):
         super(VectorFieldPlanner, self).__init__()
 

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -75,11 +75,14 @@ class GreedyIKPlanner(BasePlanner):
                         openravepy.poseFromMatrix(start_pose))
             traj.Insert(traj.GetNumWaypoints(),
                         openravepy.poseFromMatrix(goal_pose))
-            openravepy.planningutils.RetimeAffineTrajectory(
-                traj,
-                maxvelocities=0.1 * numpy.ones(7),
-                maxaccelerations=0.1 * numpy.ones(7)
-            )
+
+            with robot.CreateRobotStateSaver(
+                Robot.SaveParameters.LinkTransformation):
+                openravepy.planningutils.RetimeAffineTrajectory(
+                    traj,
+                    maxvelocities=0.1 * numpy.ones(7),
+                    maxaccelerations=0.1 * numpy.ones(7)
+                )
 
         qtraj = self.PlanWorkspacePath(robot, traj, timelimit)
         # modify tags to reflect that we won't care about
@@ -140,11 +143,13 @@ class GreedyIKPlanner(BasePlanner):
                 max_pose[0:3, 3] += max_distance * direction
                 traj.Insert(traj.GetNumWaypoints(),
                             openravepy.poseFromMatrix(max_pose))
-            openravepy.planningutils.RetimeAffineTrajectory(
-                traj,
-                maxvelocities=0.1 * numpy.ones(7),
-                maxaccelerations=0.1 * numpy.ones(7)
-            )
+            with robot.CreateRobotStateSaver(
+                Robot.SaveParameters.LinkTransformation):
+                openravepy.planningutils.RetimeAffineTrajectory(
+                    traj,
+                    maxvelocities=0.1 * numpy.ones(7),
+                    maxaccelerations=0.1 * numpy.ones(7)
+                )
 
         return self.PlanWorkspacePath(robot, traj,
                                       timelimit, min_waypoint_index=1)

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -34,13 +34,13 @@ import numpy
 import openravepy
 import time
 from ..util import SetTrajectoryTags
-from base import BasePlanner, PlanningError, LockedPlanningMethod, Tags
+from base import Planner, PlanningError, LockedPlanningMethod, Tags
 from openravepy import Robot
 
 logger = logging.getLogger(__name__)
 
 
-class GreedyIKPlanner(BasePlanner):
+class GreedyIKPlanner(Planner):
     def __init__(self):
         super(GreedyIKPlanner, self).__init__()
 

--- a/src/prpy/planning/workspace.py
+++ b/src/prpy/planning/workspace.py
@@ -77,7 +77,7 @@ class GreedyIKPlanner(BasePlanner):
                         openravepy.poseFromMatrix(goal_pose))
 
             with robot.CreateRobotStateSaver(
-                Robot.SaveParameters.LinkTransformation):
+                    Robot.SaveParameters.LinkTransformation):
                 openravepy.planningutils.RetimeAffineTrajectory(
                     traj,
                     maxvelocities=0.1 * numpy.ones(7),
@@ -144,7 +144,7 @@ class GreedyIKPlanner(BasePlanner):
                 traj.Insert(traj.GetNumWaypoints(),
                             openravepy.poseFromMatrix(max_pose))
             with robot.CreateRobotStateSaver(
-                Robot.SaveParameters.LinkTransformation):
+                    Robot.SaveParameters.LinkTransformation):
                 openravepy.planningutils.RetimeAffineTrajectory(
                     traj,
                     maxvelocities=0.1 * numpy.ones(7),

--- a/tests/planning/test_OpenRAVEPlanner.py
+++ b/tests/planning/test_OpenRAVEPlanner.py
@@ -1,0 +1,15 @@
+#!/usr/bin/env python
+from methods import (
+    PlanToConfigurationTest,
+    PlanToConfigurationStraightLineTest
+)
+from planning_helpers import BasePlannerTest
+from methods.PlanToConfiguration import PlanToConfigurationTestCollisionTest
+from prpy.planning.openrave import OpenRAVEPlanner
+from unittest import TestCase
+
+
+class OpenRAVEPlannerTest(BasePlannerTest,
+                          PlanToConfigurationTest,
+                          TestCase):
+    planner_factory = OpenRAVEPlanner

--- a/tests/planning/test_OpenRAVEPlanner.py
+++ b/tests/planning/test_OpenRAVEPlanner.py
@@ -1,10 +1,8 @@
 #!/usr/bin/env python
 from methods import (
     PlanToConfigurationTest,
-    PlanToConfigurationStraightLineTest
 )
 from planning_helpers import BasePlannerTest
-from methods.PlanToConfiguration import PlanToConfigurationTestCollisionTest
 from prpy.planning.openrave import OpenRAVEPlanner
 from unittest import TestCase
 


### PR DESCRIPTION
This PR changes `ClonedPlanningMethod` to `LockedPlanningMethod` in SnapPlanner, GreedyIKPlanner, CBiRRT, IKPlanner, NamedPlanner, OMPLPlanner, OpenRavePlanner, VectorField, TSRPlanner. 

Now each `PlanTo..` method uses `robot.env()` instead of `self.env()`. `robot.CreateRobotStateSaver(...)` has been added to necessary blocks. 
