### PR TITLE
Feature/mimic traj

### DIFF
--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -235,6 +235,12 @@ class CBiRRTPlanner(Planner):
                 
         #TODO need to change robot.GetActiveDOF() to something else
         # That can take into account another robot
+
+        #FIXME Ordinally we perform this check. However it assumes that
+        # we are only planning for the robot, which is not true
+        # if we are planning a constrained task with an object
+        # (ie opening a door). I'm unsure how to modify this check 
+        # to account for that. 
         if jointgoals is not None:
             for goal_config in jointgoals:
                 '''
@@ -252,6 +258,7 @@ class CBiRRTPlanner(Planner):
             if len(jointgoals) > 1:
                 is_endpoint_deterministic = False
 
+        raw_input("Continue?")
         if tsr_chains is not None:
             for tsr_chain in tsr_chains:
                 args += ['TSRChain', SerializeTSRChain(tsr_chain)]

--- a/src/prpy/planning/cbirrt.py
+++ b/src/prpy/planning/cbirrt.py
@@ -292,7 +292,7 @@ class CBiRRTPlanner(Planner):
             response = problem.SendCommand(args_str, True)
 
         with CollisionOptionsStateSaver(env.GetCollisionChecker(), options):
-            response = self.problem.SendCommand(args_str, True)
+            response = problem.SendCommand(args_str, True)
 
         if not response.strip().startswith('1'):
             raise PlanningError('Unknown error: ' + response,
@@ -304,25 +304,25 @@ class CBiRRTPlanner(Planner):
             traj = openravepy.RaveCreateTrajectory(env, '')
             traj.deserialize(traj_xml)
 
-
-        #TODO Mimic traj processing. Change format?
+        # Mimic traj processing if requested
         if save_mimic_trajectories:
             from prpy.util import CopyTrajectory
 
             cspec = traj.GetConfigurationSpecification()
             traj_bodies = cspec.ExtractUsedBodies(robot.GetEnv())
-            
+          
+            # Extract non-robot trajecotry
             self.mimic_trajectories = {}
             for body in traj_bodies:
                 if body.GetName() == robot.GetName():
                     continue
 
+                
                 object_cspec = body.GetActiveConfigurationSpecification('GenericTrajectory')
                 with open(traj_path, 'rb') as traj_file:
                     traj_xml = traj_file.read()
                     object_traj = openravepy.RaveCreateTrajectory(env, '')
                     object_traj.deserialize(traj_xml)
-#                object_traj = CopyTrajectory(traj)
                 openravepy.planningutils.ConvertTrajectorySpecification(object_traj, object_cspec)
                 self.mimic_trajectories[body.GetName()] = object_traj
 


### PR DESCRIPTION
Typically we plan with CBiRRT and we are only concerned with the trajectory of the robot. However, we can perform constrained planning where the robot and an object move together. Our example case has been HERB opening the frig. Therefore this extracts the non-robot trajectories from CBIRRT. To not disrupt the prpy planning pipeline, the class saves the other trajectories such that the user can grab them later. 

There is an unresolved issue that I don't know how to deal with, detailed on line 239. 