### PR TITLE
Changes for soft joint limit error handling

### DIFF
--- a/src/prpy/planning/base.py
+++ b/src/prpy/planning/base.py
@@ -544,7 +544,7 @@ class HardwareJointLimitValidator(MetaPlanner):
             try:
                 result =  plan_fn(*args, **kw_args)
             except UnsupportedPlanningError:
-                continue
+                pass
             finally:
                 if resetLimits == True:
                     robot.SetDOFLimits(soft_limit_min, soft_limit_max)

--- a/src/prpy/planning/exceptions.py
+++ b/src/prpy/planning/exceptions.py
@@ -93,6 +93,12 @@ class JointLimitError(PlanningError):
                 description=description),
             deterministic=deterministic)
 
+class SoftJointLimitError(JointLimitError):
+    pass
+
+class HardJointLimitError(JointLimitError):
+    pass
+
 
 class SelfCollisionPlanningError(CollisionPlanningError):
     pass

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -79,7 +79,6 @@ class SnapPlanner(Planner):
 
     def _Snap(self, robot, goal, **kw_args):
         from prpy.util import CheckJointLimits
-        from prpy.planning.exceptions import SoftJointLimitError
         from prpy.util import GetLinearCollisionCheckPts
         from prpy.planning.exceptions import CollisionPlanningError
         from prpy.planning.exceptions import SelfCollisionPlanningError

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -95,10 +95,8 @@ class SnapPlanner(Planner):
         # Check the start position is within joint limits,
         # this can throw a JointLimitError
         start = robot.GetActiveDOFValues()
-        try:
-            CheckJointLimits(robot, start, deterministic=True)
-        except SoftJointLimitError:
-            pass
+        
+        CheckJointLimits(robot, start, deterministic=True)
 
         # Add the start waypoint
         start_waypoint = numpy.zeros(cspec.GetDOF())
@@ -110,10 +108,9 @@ class SnapPlanner(Planner):
         # Make the trajectory end at the goal configuration, as
         # long as it is not in collision and is not identical to
         # the start configuration.
-        try:
-            CheckJointLimits(robot, goal, deterministic=True)
-        except SoftJointLimitError:
-            pass
+        
+        CheckJointLimits(robot, goal, deterministic=True)
+        
 
         if not numpy.allclose(start, goal):
             goal_waypoint = numpy.zeros(cspec.GetDOF())

--- a/src/prpy/planning/snap.py
+++ b/src/prpy/planning/snap.py
@@ -79,6 +79,7 @@ class SnapPlanner(Planner):
 
     def _Snap(self, robot, goal, **kw_args):
         from prpy.util import CheckJointLimits
+        from prpy.planning.exceptions import SoftJointLimitError
         from prpy.util import GetLinearCollisionCheckPts
         from prpy.planning.exceptions import CollisionPlanningError
         from prpy.planning.exceptions import SelfCollisionPlanningError
@@ -94,7 +95,10 @@ class SnapPlanner(Planner):
         # Check the start position is within joint limits,
         # this can throw a JointLimitError
         start = robot.GetActiveDOFValues()
-        CheckJointLimits(robot, start, deterministic=True)
+        try:
+            CheckJointLimits(robot, start, deterministic=True)
+        except SoftJointLimitError:
+            pass
 
         # Add the start waypoint
         start_waypoint = numpy.zeros(cspec.GetDOF())
@@ -106,7 +110,11 @@ class SnapPlanner(Planner):
         # Make the trajectory end at the goal configuration, as
         # long as it is not in collision and is not identical to
         # the start configuration.
-        CheckJointLimits(robot, goal, deterministic=True)
+        try:
+            CheckJointLimits(robot, goal, deterministic=True)
+        except SoftJointLimitError:
+            pass
+
         if not numpy.allclose(start, goal):
             goal_waypoint = numpy.zeros(cspec.GetDOF())
             cspec.InsertJointValues(goal_waypoint, goal, robot,

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -498,17 +498,12 @@ class VectorFieldPlanner(Planner):
             called after each integration time step, which means we are
             doing more checks than required.
             """
-            from prpy.planning.exceptions import SoftJointLimitError
-
             if time.time() - time_start >= timelimit:
                 raise TimeLimitError()
 
             # Check joint position limits.
             # We do this before setting the joint angles.
-            try:
-                util.CheckJointLimits(robot, q)
-            except SoftJointLimitError:
-                pass
+            util.CheckJointLimits(robot, q)
 
             robot.SetActiveDOFValues(q)
 

--- a/src/prpy/planning/vectorfield.py
+++ b/src/prpy/planning/vectorfield.py
@@ -498,12 +498,17 @@ class VectorFieldPlanner(Planner):
             called after each integration time step, which means we are
             doing more checks than required.
             """
+            from prpy.planning.exceptions import SoftJointLimitError
+
             if time.time() - time_start >= timelimit:
                 raise TimeLimitError()
 
             # Check joint position limits.
             # We do this before setting the joint angles.
-            util.CheckJointLimits(robot, q)
+            try:
+                util.CheckJointLimits(robot, q)
+            except SoftJointLimitError:
+                pass
 
             robot.SetActiveDOFValues(q)
 

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1326,7 +1326,7 @@ def ComputeGeodesicUnitTiming(traj, env=None, alpha=1.0):
     return new_traj
 
 
-def CheckJointLimits(robot, q, deterministic=None):
+def CheckJointLimits(robot, q, hard_limits, deterministic=None):
     """
     Check if a configuration is within a robot's joint position limits.
 
@@ -1338,17 +1338,19 @@ def CheckJointLimits(robot, q, deterministic=None):
     """
     from prpy.planning.exceptions import JointLimitError
 
-    q_limit_min, q_limit_max = robot.GetActiveDOFLimits()
     active_dof_indices = robot.GetActiveDOFIndices()
 
     if len(q) != len(active_dof_indices):
         raise ValueError('The number of joints in the configuration q '
                          'is not equal to the number of active DOF.')
 
+    # Check for soft joint limit error
+    q_limit_min, q_limit_max = robot.GetActiveDOFLimits()
+
     lower_position_violations = (q < q_limit_min)
     if lower_position_violations.any():
         index = lower_position_violations.nonzero()[0][0]
-        raise JointLimitError(
+        raise SoftJointLimitError(
             robot,
             dof_index=active_dof_indices[index],
             dof_value=q[index],
@@ -1359,13 +1361,40 @@ def CheckJointLimits(robot, q, deterministic=None):
     upper_position_violations = (q > q_limit_max)
     if upper_position_violations.any():
         index = upper_position_violations.nonzero()[0][0]
-        raise JointLimitError(
+        raise SoftJointLimitError(
             robot,
             dof_index=active_dof_indices[index],
             dof_value=q[index],
             dof_limit=q_limit_max[index],
             description='position',
             deterministic=deterministic)
+
+
+    # Soft Joint Limit Error implies Hard Limit Error but not vice versa
+    hard_limit_min, hard_limit_max = hard_limits
+
+    lower_position_violations = (q < hard_limit_min)
+    if lower_position_violations.any():
+        index = lower_position_violations.nonzero()[0][0]
+        raise HardJointLimitError(
+            robot,
+            dof_index=active_dof_indices[index],
+            dof_value=q[index],
+            dof_limit=q_limit_min[index],
+            description='position',
+            deterministic=deterministic)
+
+    upper_position_violations = (q > hard_limit_max)
+    if upper_position_violations.any():
+        index = upper_position_violations.nonzero()[0][0]
+        raise HardJointLimitError(
+            robot,
+            dof_index=active_dof_indices[index],
+            dof_value=q[index],
+            dof_limit=q_limit_max[index],
+            description='position',
+            deterministic=deterministic)
+
 
 
 def GetForwardKinematics(robot, q, manipulator=None, frame=None):

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1326,7 +1326,7 @@ def ComputeGeodesicUnitTiming(traj, env=None, alpha=1.0):
     return new_traj
 
 
-def CheckJointLimits(robot, q, hard_limits, deterministic=None):
+def CheckJointLimits(robot, q, deterministic=None):
     """
     Check if a configuration is within a robot's joint position limits.
 
@@ -1362,32 +1362,6 @@ def CheckJointLimits(robot, q, hard_limits, deterministic=None):
     if upper_position_violations.any():
         index = upper_position_violations.nonzero()[0][0]
         raise SoftJointLimitError(
-            robot,
-            dof_index=active_dof_indices[index],
-            dof_value=q[index],
-            dof_limit=q_limit_max[index],
-            description='position',
-            deterministic=deterministic)
-
-
-    # Soft Joint Limit Error implies Hard Limit Error but not vice versa
-    hard_limit_min, hard_limit_max = hard_limits
-
-    lower_position_violations = (q < hard_limit_min)
-    if lower_position_violations.any():
-        index = lower_position_violations.nonzero()[0][0]
-        raise HardJointLimitError(
-            robot,
-            dof_index=active_dof_indices[index],
-            dof_value=q[index],
-            dof_limit=q_limit_min[index],
-            description='position',
-            deterministic=deterministic)
-
-    upper_position_violations = (q > hard_limit_max)
-    if upper_position_violations.any():
-        index = upper_position_violations.nonzero()[0][0]
-        raise HardJointLimitError(
             robot,
             dof_index=active_dof_indices[index],
             dof_value=q[index],

--- a/src/prpy/util.py
+++ b/src/prpy/util.py
@@ -1336,7 +1336,7 @@ def CheckJointLimits(robot, q, deterministic=None):
     @param openravepy.robot robot: The robot.
     @param list             q:     List or array of joint positions.
     """
-    from prpy.planning.exceptions import JointLimitError
+    from prpy.planning.exceptions import SoftJointLimitError
 
     active_dof_indices = robot.GetActiveDOFIndices()
 


### PR DESCRIPTION
This allows the disambiguation between the joint limits from the `openrave Robot` and the actual joint limits of the hardware (from looking up specs). Currently, the two `prpy` planners that call `CheckJointLimits` are now configured to catch `SoftJointLimitError` exceptions and continue.

@gilwoolee please take a look. There aren't many changes, and this is definitely still in progress. We also need to something about OMPL planners.