### PR TITLE
Removing an encode line which causes AttributeError

### DIFF
--- a/src/prpy/serialization.py
+++ b/src/prpy/serialization.py
@@ -660,7 +660,7 @@ JOINT_INFO_MAP = {
     '_name': str_identity,
     '_type': (
         lambda x: x.name,
-        lambda x: openravepy.KinBody.JointType.names[x].encode()
+        lambda x: openravepy.KinBody.JointType.names[x]
     ),
     '_vanchor': numpy_identity,
     '_vaxes': (


### PR DESCRIPTION
While deserializing with the current setup I get the following error:

```
/home/shushman/ros_control_ws/src/prpy/src/prpy/serialization.pyc in <lambda>(x)
    661     '_type': (
    662         lambda x: x.name,
--> 663         lambda x: openravepy.KinBody.JointType.names[x].encode()
    664     ),
    665     '_vanchor': numpy_identity,

AttributeError: 'JointType' object has no attribute 'encode'
```

Removing the `.encode`, as suggested by @mkoval , seems to fix this. Should that change be made permanent?