### PR TITLE
Fix Python syntax error in meta.py

### DIFF
--- a/src/prpy/perception/meta.py
+++ b/src/prpy/perception/meta.py
@@ -1,24 +1,24 @@
 #!/usr/bin/env python
 
 import functools
-        
+
 from base import PerceptionModule, PerceptionMethod
 
-class MetaModule(PerceptionModule)
+class MetaModule(PerceptionModule):
     def __init__(self, modules):
         super(PerceptionModule, self).__init__()
         self.modules = modules;
-    
+
     def __str__(self):
         return 'MetaModule'
-        
-class RunAll(MetaModule)
+
+class RunAll(MetaModule):
     def __init__(self, modules):
         super(MetaModule, self).__init__(modules)
-    
+
     def __str__(self):
         return 'RunAll'
-    
+
     @PerceptionMethod
     def DetectObjects(self, robot, **kw_args):
         for module in modules:


### PR DESCRIPTION
Class definitions didn't have colons. This would cause an error if trying to import `meta.py`. This will cause an error in installation as well in the step where `.py` files are compiled to `.pyc` files, which is where I noticed it.